### PR TITLE
fix #627: In contract transfer not block negative amount

### DIFF
--- a/core/contract/bridge/syscall_service.go
+++ b/core/contract/bridge/syscall_service.go
@@ -125,6 +125,10 @@ func (c *SyscallService) Transfer(ctx context.Context, in *pb.TransferRequest) (
 	if !ok {
 		return nil, errors.New("parse amount error")
 	}
+	// make sure amount is not negative
+	if amount.Cmp(new(big.Int)) < 0 {
+		return nil, errors.New("amount should not be negative")
+	}
 	if in.GetTo() == "" {
 		return nil, errors.New("empty to address")
 	}


### PR DESCRIPTION
## Description

This PR Fixes #627 : In contract transfer not block negative amount.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Block negative amount of in contract transfer in XuperBridge, 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
