### PR TITLE
enhance receive block height logic

### DIFF
--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -402,7 +402,7 @@ func (xc *XChainCore) SendBlock(in *pb.Block, hd *global.XContext) error {
 		return ErrBlockExist
 	}
 	// Note in BFT case, we should accept blocks with same hight
-	if in.Block.Height < xc.Ledger.GetMeta().TrunkHeight {
+	if in.Block.Height <= xc.Ledger.GetMeta().TrunkHeight-3 {
 		xc.log.Warn("refuse short chain of blocks", "remote", in.Block.Height, "local", xc.Ledger.GetMeta().TrunkHeight)
 		return ErrServiceRefused
 	}


### PR DESCRIPTION
## Description

What is the purpose of the change?
Now node will reject the block height less than the thunk height. It's better to reject height less than 3 so that in xdpos block will confirmed after 3 block.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
