### PR TITLE
bugfix: frozenHeight includes -1

### DIFF
--- a/core/pb/helper.go
+++ b/core/pb/helper.go
@@ -13,7 +13,7 @@ const FeePlaceholder = "$"
 func (tx *Transaction) GetFrozenAmount(height int64) *big.Int {
 	sum := big.NewInt(0)
 	for _, txOutput := range tx.TxOutputs {
-		if txOutput.FrozenHeight > height {
+		if txOutput.FrozenHeight > height || txOutput.FrozenHeight == -1 {
 			amount := big.NewInt(0)
 			amount.SetBytes(txOutput.Amount)
 			sum = sum.Add(sum, amount)


### PR DESCRIPTION
## Description

What is the purpose of the change?
FrozenHeight doesn't support the case where the frozen equals -1 for voting.

Fixes #636 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Brief of your solution

Add the condition judgement of frozenHeight equaling -1.

## How Has This Been Tested?

Regression Test
