### PR TITLE
opt: clear locked utxo when merging utxo again

### DIFF
--- a/core/utxo/merge_utxo.go
+++ b/core/utxo/merge_utxo.go
@@ -23,6 +23,9 @@ func (uv *UtxoVM) SelectUtxosBySize(fromAddr string, fromPubKey string, needLock
 	txInputs := []*pb.TxInput{}
 	txInputSize := int64(0)
 
+	// same as the logic of SelectUTXO
+	uv.clearExpiredLocks()
+
 	addrPrefix := fmt.Sprintf("%s%s_", pb.UTXOTablePrefix, fromAddr)
 	it := uv.ldb.NewIteratorWithPrefix([]byte(addrPrefix))
 	defer it.Release()


### PR DESCRIPTION
## Description

What is the purpose of the change?
behavior as SelectUtxos

Fixes #639 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Brief of your solution

Add the method of UtxoVM.clearExpiredLocks()

## How Has This Been Tested?

Regression Test
