### PR TITLE
bugfix: no utxo support

### DIFF
--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -475,10 +475,6 @@ func (xc *XChainCore) SendBlock(in *pb.Block, hd *global.XContext) error {
 			xc.log.Debug("ConfirmBlock Time", "logid", in.Header.Logid, "cost", hd.Timer.Print())
 			if !cs.Succ {
 				xc.log.Warn("confirm error", "logid", in.Header.Logid)
-				err := xc.Utxovm.Walk(xc.Utxovm.GetMeta().LatestBlockid, false)
-				if err != nil {
-					xc.log.Warn("try to walk utxo, but failed", "err", err)
-				}
 				return ErrConfirmBlock
 			}
 			isTipBlock := (i == 0)

--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -475,6 +475,10 @@ func (xc *XChainCore) SendBlock(in *pb.Block, hd *global.XContext) error {
 			xc.log.Debug("ConfirmBlock Time", "logid", in.Header.Logid, "cost", hd.Timer.Print())
 			if !cs.Succ {
 				xc.log.Warn("confirm error", "logid", in.Header.Logid)
+				err := xc.Utxovm.Walk(xc.Utxovm.GetMeta().LatestBlockid, false)
+				if err != nil {
+					xc.log.Warn("try to walk utxo, but failed", "err", err)
+				}
 				return ErrConfirmBlock
 			}
 			isTipBlock := (i == 0)
@@ -678,6 +682,10 @@ func (xc *XChainCore) doMiner() {
 		xc.log.Info("[Minning] ConfirmBlock Success", "logid", header.Logid, "Height", meta.TrunkHeight+1)
 	} else {
 		xc.log.Warn("[Minning] ConfirmBlock Fail", "logid", header.Logid, "confirm_status", confirmStatus)
+		err := xc.Utxovm.Walk(xc.Utxovm.GetLatestBlockid(), false)
+		if err != nil {
+			xc.log.Warn("[Mining] failed to walk when confirming block has error", "err", err)
+		}
 		return
 	}
 	xc.mutex.Unlock() //后面放开锁

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -2439,7 +2439,7 @@ func ValidTxInput(tx *pb.Transaction) error {
 	if tx.GetTxInputs() == nil {
 		return nil
 	}
-	for _, v := range tx {
+	for _, v := range tx.GetTxInputs() {
 		if v != nil {
 			return errors.New("has utxo input")
 		}

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -1278,8 +1278,7 @@ func (uv *UtxoVM) doTxSync(tx *pb.Transaction) error {
 	if TxInputsWithoutUtxo(tx) {
 		exist, err := uv.ledger.HasTransaction(tx.GetTxid())
 		if exist {
-			errMsg := fmt.Sprintf("%x", tx.GetTxid()) + "has existed already"
-			return errors.New(errMsg)
+			return fmt.Errorf("%x has existed already", tx.GetTxid())
 		}
 		if err != nil {
 			return err

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -263,12 +263,11 @@ func (uv *UtxoVM) checkInputEqualOutput(tx *pb.Transaction) error {
 		}
 		inputSum.Add(inputSum, amount)
 	}
-
-	if inputSum.Cmp(big.NewInt(0)) == 0 && tx.Coinbase {
-		// coinbase交易，输入输出不必相等, 特殊处理
+	if inputSum.Cmp(outputSum) == 0 {
 		return nil
 	}
-	if inputSum.Cmp(outputSum) == 0 {
+	if inputSum.Cmp(big.NewInt(0)) == 0 && tx.Coinbase {
+		// coinbase交易，输入输出不必相等, 特殊处理
 		return nil
 	}
 	uv.xlog.Warn("input != output", "inputSum", inputSum, "outputSum", outputSum)

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -1275,7 +1275,7 @@ func (uv *UtxoVM) doTxSync(tx *pb.Transaction) error {
 		uv.xlog.Debug("this tx already in unconfirm table, when DoTx", "txid", fmt.Sprintf("%x", tx.Txid))
 		return ErrAlreadyInUnconfirmed
 	}
-	if ValidTxIsNoUtxo(tx) {
+	if TxInputsWithoutUtxo(tx) {
 		exist, err := uv.ledger.HasTransaction(tx.GetTxid())
 		if exist {
 			errMsg := fmt.Sprintf("%x", tx.GetTxid()) + "has existed already"
@@ -2435,7 +2435,7 @@ func MakeUtxoKey(key []byte, amount string) *pb.UtxoKey {
 	return tmpUtxoKey
 }
 
-func ValidTxIsNoUtxo(tx *pb.Transaction) bool {
+func TxInputsWithoutUtxo(tx *pb.Transaction) bool {
 	if tx.GetTxInputs() == nil {
 		return true
 	}

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -1275,7 +1275,7 @@ func (uv *UtxoVM) doTxSync(tx *pb.Transaction) error {
 		uv.xlog.Debug("this tx already in unconfirm table, when DoTx", "txid", fmt.Sprintf("%x", tx.Txid))
 		return ErrAlreadyInUnconfirmed
 	}
-	if ValidTxInput(tx) == nil {
+	if ValidTxIsNoUtxo(tx) {
 		exist, err := uv.ledger.HasTransaction(tx.GetTxid())
 		if exist {
 			errMsg := fmt.Sprintf("%x", tx.GetTxid()) + "has existed already"
@@ -2435,15 +2435,15 @@ func MakeUtxoKey(key []byte, amount string) *pb.UtxoKey {
 	return tmpUtxoKey
 }
 
-func ValidTxInput(tx *pb.Transaction) error {
+func ValidTxIsNoUtxo(tx *pb.Transaction) bool {
 	if tx.GetTxInputs() == nil {
-		return nil
+		return true
 	}
 	for _, v := range tx.GetTxInputs() {
 		if v != nil {
-			return errors.New("has utxo input")
+			return false
 		}
 	}
 
-	return nil
+	return true
 }

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -1275,15 +1275,6 @@ func (uv *UtxoVM) doTxSync(tx *pb.Transaction) error {
 		uv.xlog.Debug("this tx already in unconfirm table, when DoTx", "txid", fmt.Sprintf("%x", tx.Txid))
 		return ErrAlreadyInUnconfirmed
 	}
-	if TxInputsWithoutUtxo(tx) {
-		exist, err := uv.ledger.HasTransaction(tx.GetTxid())
-		if exist {
-			return fmt.Errorf("%x has existed already", tx.GetTxid())
-		}
-		if err != nil {
-			return err
-		}
-	}
 	batch := uv.ldb.NewBatch()
 	doErr := uv.doTxInternal(tx, batch)
 	if doErr != nil {
@@ -2432,17 +2423,4 @@ func MakeUtxoKey(key []byte, amount string) *pb.UtxoKey {
 	}
 
 	return tmpUtxoKey
-}
-
-func TxInputsWithoutUtxo(tx *pb.Transaction) bool {
-	if tx.GetTxInputs() == nil {
-		return true
-	}
-	for _, v := range tx.GetTxInputs() {
-		if v != nil {
-			return false
-		}
-	}
-
-	return true
 }


### PR DESCRIPTION
## Description

What is the purpose of the change?

In current case, the tx in the model of no utxo can exist in the unconfirmed and confirmed table both, which caused the native ledger doesn't grow any more.

Fixes #644

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

take the case where input equals output and input equals 0 into consideration
No need to add a switch for no utxo model

## How Has This Been Tested?

Regression Test
