### PR TITLE
bugfix: return err when pub.X or pub.Y is nil

### DIFF
--- a/core/crypto/account/address.go
+++ b/core/crypto/account/address.go
@@ -18,6 +18,9 @@ import (
 
 // GetAddressFromPublicKey 返回33位长度的地址
 func GetAddressFromPublicKey(pub *ecdsa.PublicKey) (string, error) {
+	if pub.X == nil || pub.Y == nil {
+		return "", fmt.Errorf("public field is missing, pub.X:[%v], pub.Y:[%v]", pub.X, pub.Y)
+	}
 	//using SHA256 and Ripemd160 for hash summary
 	data := elliptic.Marshal(pub.Curve, pub.X, pub.Y)
 	outputSha256 := hash.UsingSha256(data)


### PR DESCRIPTION
## Description

What is the purpose of the change?
When The X or Y in public.key is nil, return err directly.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Add a validation

## How Has This Been Tested?

Regression Test
