### PR TITLE
rm dep-prev in iterator

### DIFF
--- a/core/consensus/tdpos/common.go
+++ b/core/consensus/tdpos/common.go
@@ -139,22 +139,27 @@ func (tp *TDpos) getTermProposer(term int64) []*cons_base.CandidateInfo {
 				return nil
 			}
 			if termLast == term+1 {
-				if it.Prev() {
-					tp.log.Trace("TDpos getTermProposer ", "key", string(it.Key()))
-				} else {
+				keyLast := string(it.Key())
+				it.First()
+
+				keyFirst := string(it.Key())
+				if keyFirst == keyLast {
 					tp.log.Trace("TDpos getTermProposer parseTermCheckKey get prev nil")
-					it.Last()
-					keyLast := string(it.Key())
-					it.First()
-					ketFirst := string(it.Key())
-					if keyLast == ketFirst {
-						return tp.config.initProposer[1]
-					}
-					tp.log.Warn("TDpos getTermProposer parseTermCheckKey get prev error", "error", err)
-					return nil
+					return tp.config.initProposer[1]
 				}
+
+				preKey := keyFirst
+				preVal := it.Value()
+				for it.Next() {
+					if string(it.Key()) == keyLast {
+						break
+					}
+					preKey = string(it.Key())
+					preVal = it.Value()
+				}
+				val = preVal
+				tp.log.Trace("TDpos getTermProposer ", "key", string(preKey))
 			}
-			val = it.Value()
 		} else {
 			tp.log.Warn("TDpos getTermProposer query from table is nil", "tp.config.initProposer[1]", tp.config.initProposer[1])
 			return tp.config.initProposer[1]

--- a/core/consensus/tdpos/common.go
+++ b/core/consensus/tdpos/common.go
@@ -144,7 +144,7 @@ func (tp *TDpos) getTermProposer(term int64) []*cons_base.CandidateInfo {
 
 				keyFirst := string(it.Key())
 				if keyFirst == keyLast {
-					tp.log.Trace("TDpos getTermProposer parseTermCheckKey get prev nil")
+					tp.log.Trace("TDpos getTermProposer parseTermCheckKey get prev nil", "")
 					return tp.config.initProposer[1]
 				}
 
@@ -158,8 +158,11 @@ func (tp *TDpos) getTermProposer(term int64) []*cons_base.CandidateInfo {
 					preVal = it.Value()
 				}
 				val = preVal
-				tp.log.Trace("TDpos getTermProposer ", "key", string(preKey))
+				tp.log.Trace("TDpos getTermProposer ", "available key", string(preKey),
+					"current term:", term, "last term:", termLast)
 			} else {
+				tp.log.Trace("TDpos getTermProposer ", "available key", string(it.Key()),
+					"current term:", term, "last term:", termLast)
 				val = it.Value()
 			}
 		} else {

--- a/core/consensus/tdpos/common.go
+++ b/core/consensus/tdpos/common.go
@@ -159,6 +159,8 @@ func (tp *TDpos) getTermProposer(term int64) []*cons_base.CandidateInfo {
 				}
 				val = preVal
 				tp.log.Trace("TDpos getTermProposer ", "key", string(preKey))
+			} else {
+				val = it.Value()
 			}
 		} else {
 			tp.log.Warn("TDpos getTermProposer query from table is nil", "tp.config.initProposer[1]", tp.config.initProposer[1])


### PR DESCRIPTION

## Description

What is the purpose of the change?
Why?
  prev in iterator is an advanced feature.
  The feature is missing in many sdks for different storage such as mongoDB.

Fixes # (issue)

## Type of change
- [ ] This change requires a documentation update

## Brief of your solution

When to use prev() in iterator?
It's a special case where the miner node stops mining for a long time without more term validators having been persisted, with the last efficient term validators.
How to instead of prev() with next() in iterator?
Use next of iterator til current key is same as lastKey.

## How Has This Been Tested?

