### PR TITLE
bugfix:get visual peerID

### DIFF
--- a/core/core/group_chain.go
+++ b/core/core/group_chain.go
@@ -32,9 +32,14 @@ func (xm *XChainMG) IsPeerInGroupChain(bcname, remotePeerID string) bool {
 	xm.groupChainCache.Mutex.Lock()
 	defer xm.groupChainCache.Mutex.Unlock()
 	ipSet, ipSetExist := xm.groupChainCache.StreamContractCache[bcname]
-	if !ipSetExist || len(ipSet) == 0 {
+	// ipSetExist代表是否有群组属性
+	// len(ipSet)代表bcname的白名单数量
+	if !ipSetExist {
 		return true
+	} else if len(ipSet) == 0 {
+		return false
 	}
+
 	// 如果本地没有远程传来的节点id，直接拒绝
 	ip, ipExist := xm.groupChainCache.StreamCache[remotePeerID]
 	if !ipExist {
@@ -74,6 +79,9 @@ func (xm *XChainMG) GetAllowedPeersWithBcname(bcname string) map[string]bool {
 		if localIP == ip {
 			allowedPeersMap[peerID] = true
 		}
+	}
+	if len(allowedPeersMap) == 0 {
+		allowedPeersMap["MAGIC_PEERID"] = true
 	}
 
 	return allowedPeersMap

--- a/core/p2p/p2pv2/server.go
+++ b/core/p2p/p2pv2/server.go
@@ -110,8 +110,7 @@ func (p *P2PServerV2) SendMessage(ctx context.Context, msg *p2pPb.XuperMessage,
 	whiteList := msgOpts.WhiteList
 	if len(whiteList) > 0 {
 		for _, v := range peers.([]peer.ID) {
-			rawPeerID := fmt.Sprintf("%s", v)
-			if _, exist := whiteList[rawPeerID]; exist {
+			if _, exist := whiteList[v.Pretty()]; exist {
 				peersRes = append(peersRes, v)
 			}
 		}
@@ -144,8 +143,7 @@ func (p *P2PServerV2) SendMessageWithResponse(ctx context.Context, msg *p2pPb.Xu
 	whiteList := msgOpts.WhiteList
 	if len(whiteList) > 0 {
 		for _, v := range peers.([]peer.ID) {
-			rawPeerID := fmt.Sprintf("%s", v)
-			if _, exist := whiteList[rawPeerID]; exist {
+			if _, exist := whiteList[v.Pretty()]; exist {
 				peersRes = append(peersRes, v)
 			}
 		}

--- a/core/p2p/p2pv2/server.go
+++ b/core/p2p/p2pv2/server.go
@@ -110,7 +110,8 @@ func (p *P2PServerV2) SendMessage(ctx context.Context, msg *p2pPb.XuperMessage,
 	whiteList := msgOpts.WhiteList
 	if len(whiteList) > 0 {
 		for _, v := range peers.([]peer.ID) {
-			if _, exist := whiteList[string(v)]; exist {
+			rawPeerID := fmt.Sprintf("%s", v)
+			if _, exist := whiteList[rawPeerID]; exist {
 				peersRes = append(peersRes, v)
 			}
 		}
@@ -143,7 +144,8 @@ func (p *P2PServerV2) SendMessageWithResponse(ctx context.Context, msg *p2pPb.Xu
 	whiteList := msgOpts.WhiteList
 	if len(whiteList) > 0 {
 		for _, v := range peers.([]peer.ID) {
-			if _, exist := whiteList[string(v)]; exist {
+			rawPeerID := fmt.Sprintf("%s", v)
+			if _, exist := whiteList[rawPeerID]; exist {
 				peersRes = append(peersRes, v)
 			}
 		}


### PR DESCRIPTION
## Description

What is the purpose of the change?
bugfix: group ability
Get peerID using fmt.Sprintf instead of string

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Brief of your solution

Get peerID using fmt.Sprintf instead of string

## How Has This Been Tested?

Regression Test
