### PR TITLE
p2pv1 support xpos

### DIFF
--- a/core/consensus/common/chainedbft/smr/smr.go
+++ b/core/consensus/common/chainedbft/smr/smr.go
@@ -118,7 +118,6 @@ func (s *Smr) Start() {
 			go s.handleReceivedMsg(msg)
 		case <-s.QuitCh:
 			s.slog.Info("Quit chainedbft smr ...")
-			s.QuitCh <- true
 			s.stop()
 			return
 		}
@@ -127,7 +126,6 @@ func (s *Smr) Start() {
 
 // stop used to stop smr instance
 func (s *Smr) stop() {
-	// TODO: zq
 }
 
 // ProcessNewView used to process while view changed. There are three scenarios:

--- a/core/p2p/p2pv1/conn_pool.go
+++ b/core/p2p/p2pv1/conn_pool.go
@@ -67,7 +67,7 @@ func (cp *ConnPool) Remove(conn *Conn) error {
 	return nil
 }
 
-// Find find conn from connpool
+// Find find conn from connpool, it will establish with the addr if haven't been connected
 func (cp *ConnPool) Find(addr string) (*Conn, error) {
 	if cp.conns[addr] != nil {
 		return cp.conns[addr], nil

--- a/core/p2p/p2pv1/filter.go
+++ b/core/p2p/p2pv1/filter.go
@@ -1,5 +1,9 @@
 package p2pv1
 
+import (
+	p2p_base "github.com/xuperchain/xuperchain/core/p2p/base"
+)
+
 // StaticNodeStrategy a peer filter that contains strategy nodes
 type StaticNodeStrategy struct {
 	isBroadCast bool
@@ -57,4 +61,49 @@ func (cp *CorePeersFilter) SetRouteName(name string) {
 // half from current and half from next
 func (cp *CorePeersFilter) Filter() (interface{}, error) {
 	return nil, nil
+}
+
+// MultiStrategy a peer filter that contains multiple filters
+type MultiStrategy struct {
+	filters     []p2p_base.PeersFilter
+	targetPeers []string
+}
+
+// NewMultiStrategy create instance of MultiStrategy
+func NewMultiStrategy(filters []p2p_base.PeersFilter, targetPeers []string) *MultiStrategy {
+	return &MultiStrategy{
+		filters:     filters,
+		targetPeers: targetPeers,
+	}
+}
+
+// Filter return peer IDs with multiple filters
+func (cp *MultiStrategy) Filter() (interface{}, error) {
+	res := make([]string, 0)
+	dupCheck := make(map[string]bool)
+	// add target peers
+	for _, peer := range cp.targetPeers {
+		if _, ok := dupCheck[peer]; !ok {
+			dupCheck[peer] = true
+			res = append(res, peer)
+		}
+	}
+	if len(res) > 0 {
+		return res, nil
+	}
+
+	// add all filters
+	for _, filter := range cp.filters {
+		peers, err := filter.Filter()
+		if err != nil {
+			return res, err
+		}
+		for _, peer := range peers.([]string) {
+			if _, ok := dupCheck[peer]; !ok {
+				dupCheck[peer] = true
+				res = append(res, peer)
+			}
+		}
+	}
+	return res, nil
 }


### PR DESCRIPTION
## Description

What is the purpose of the change?
XuperChain support p2pv1 at v3.6. But it doesn't support xpos consensus as chained-bft validates need to gather votes from other validates. But p2pv1 only support `staticnode` filter. 

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Brief of your solution
This  pr support  `withTargetAddrs` option  of p2pv1 so it can support xpos consensus.

## How Has This Been Tested?

Add addrs in genesis config as following:

```
"init_proposer_neturl": {
    "1": ["127.0.0.1:47102","127.0.0.1:47103","127.0.0.1:47104"]
 }, "bft_config": {}

```


