### PR TITLE
xmodel: use XMReader instead of XModel

### DIFF
--- a/core/contract/wasm/vm_manager.go
+++ b/core/contract/wasm/vm_manager.go
@@ -29,7 +29,7 @@ import (
 type VMManager struct {
 	basedir      string
 	config       *config.WasmConfig
-	xmodel       *xmodel.XModel
+	xmodel       xmodel.XMReader
 	syscall      *bridge.SyscallService
 	vmimpl       vm.InstanceCreator
 	xbridge      *bridge.XBridge
@@ -38,7 +38,7 @@ type VMManager struct {
 }
 
 // New instances a new VMManager
-func New(cfg *config.WasmConfig, basedir string, xbridge *bridge.XBridge, xmodel *xmodel.XModel) (*VMManager, error) {
+func New(cfg *config.WasmConfig, basedir string, xbridge *bridge.XBridge, xmodel xmodel.XMReader) (*VMManager, error) {
 	vmm := &VMManager{
 		basedir:      basedir,
 		config:       cfg,
@@ -47,12 +47,11 @@ func New(cfg *config.WasmConfig, basedir string, xbridge *bridge.XBridge, xmodel
 		codeProvider: newCodeProvider(xmodel),
 	}
 
-	pluginMgr, err := pluginmgr.GetPluginMgr()
-	if err != nil {
-		return nil, err
-	}
-
 	if cfg.External {
+		pluginMgr, err := pluginmgr.GetPluginMgr()
+		if err != nil {
+			return nil, err
+		}
 		if _, err = pluginMgr.PluginMgr.CreatePluginInstance("wasm", cfg.Driver); err != nil {
 			return nil, err
 		}

--- a/core/xmodel/interface.go
+++ b/core/xmodel/interface.go
@@ -1,7 +1,6 @@
 package xmodel
 
 import (
-	"github.com/xuperchain/xuperchain/core/pb"
 	xmodel_pb "github.com/xuperchain/xuperchain/core/xmodel/pb"
 )
 
@@ -21,8 +20,4 @@ type XMReader interface {
 	Get(bucket string, key []byte) (*xmodel_pb.VersionedData, error)
 	//扫描一个bucket中所有的kv, 调用者可以设置key区间[startKey, endKey)
 	Select(bucket string, startKey []byte, endKey []byte) (Iterator, error)
-	//查询交易
-	QueryTx(txid []byte) (*pb.Transaction, bool, error)
-	//查询区块
-	QueryBlock(blockid []byte) (*pb.InternalBlock, error)
 }

--- a/core/xmodel/xmodel_cache.go
+++ b/core/xmodel/xmodel_cache.go
@@ -45,12 +45,12 @@ type XMCache struct {
 	outputsCache *memdb.DB
 	// 是否穿透到model层
 	isPenetrate bool
-	model       *XModel
+	model       XMReader
 	utxoCache   *UtxoCache
 }
 
 // NewXModelCache new an instance of XModel Cache
-func NewXModelCache(model *XModel, utxovm UtxoVM) (*XMCache, error) {
+func NewXModelCache(model XMReader, utxovm UtxoVM) (*XMCache, error) {
 	return &XMCache{
 		isPenetrate:  true,
 		model:        model,


### PR DESCRIPTION
## Description

Using interfaces can make mocking more convenient.