### PR TITLE
split big lock to improve performance

### DIFF
--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -914,7 +914,7 @@ func (xc *XChainCore) PostTx(in *pb.TxStatus, hd *global.XContext) (*pb.CommonRe
 	if err != nil {
 		out.Header.Error = HandlerUtxoError(err)
 		if err != utxo.ErrAlreadyInUnconfirmed {
-			xc.log.Warn("utxo vm do tx error", "logid", in.Header.Logid, "error", err)
+			xc.log.Info("utxo vm do tx error", "logid", in.Header.Logid, "error", err)
 		}
 		return out, false
 	}

--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -905,7 +905,6 @@ func (xc *XChainCore) PostTx(in *pb.TxStatus, hd *global.XContext) (*pb.CommonRe
 		default:
 			out.Header.Error = pb.XChainErrorEnum_TX_VERIFICATION_ERROR
 		}
-		xc.txidCache.Delete(txidStr)
 		xc.log.Warn("post tx verify tx error", "txid", global.F(in.Tx.Txid),
 			"valid_err", validErr, "logid", in.Header.Logid)
 		return out, false

--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -905,6 +905,7 @@ func (xc *XChainCore) PostTx(in *pb.TxStatus, hd *global.XContext) (*pb.CommonRe
 		default:
 			out.Header.Error = pb.XChainErrorEnum_TX_VERIFICATION_ERROR
 		}
+		xc.txidCache.Delete(txidStr)
 		xc.log.Warn("post tx verify tx error", "txid", global.F(in.Tx.Txid),
 			"valid_err", validErr, "logid", in.Header.Logid)
 		return out, false

--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -74,7 +74,7 @@ var (
 
 const (
 	// MaxReposting max repost times for broadcats
-	MaxReposting = 1024 // tx重试广播的最大并发，过多容易打爆对方的grpc连接数
+	MaxReposting = 3000 // tx重试广播的最大并发，过多容易打爆对方的grpc连接数
 	// RepostingInterval repost retry interval, ms
 	RepostingInterval = 500 // 重试广播间隔ms
 	TxidCacheGcTime   = 180 * time.Second
@@ -356,7 +356,7 @@ func (xc *XChainCore) repostOfflineTx() {
 			p2p_base.WithCompress(xc.enableCompress),
 			p2p_base.WithWhiteList(whiteList),
 		}
-		xc.P2pSvr.SendMessage(context.Background(), msg, opts...) //p2p广播出去
+		go xc.P2pSvr.SendMessage(context.Background(), msg, opts...) //p2p广播出去
 	}
 }
 

--- a/core/ledger/ledger.go
+++ b/core/ledger/ledger.go
@@ -695,7 +695,7 @@ func (l *Ledger) ConfirmBlock(block *pb.InternalBlock, isRoot bool) ConfirmStatu
 					"blockid", fmt.Sprintf("%x", oldBlock.Blockid))
 				return confirmStatus
 			} else if block.InTrunk {
-				l.xlog.Warn("change blockid of tx", "txid", fmt.Sprintf("%x", tx.Txid), "blockid", fmt.Sprintf("%x", block.Blockid))
+				l.xlog.Info("change blockid of tx", "txid", fmt.Sprintf("%x", tx.Txid), "blockid", fmt.Sprintf("%x", block.Blockid))
 				batchWrite.Put(append([]byte(pb.ConfirmedTablePrefix), tx.Txid...), pbTxBuf)
 			}
 		}

--- a/core/ledger/ledger.go
+++ b/core/ledger/ledger.go
@@ -646,6 +646,7 @@ func (l *Ledger) ConfirmBlock(block *pb.InternalBlock, isRoot bool) ConfirmStatu
 	}
 	txExist, txData := l.parallelCheckTx(realTransactions, block)
 	cbNum := 0
+	oldBlockCache := map[string]*pb.InternalBlock{}
 	for _, tx := range realTransactions {
 		if tx.Coinbase {
 			cbNum = cbNum + 1
@@ -675,17 +676,25 @@ func (l *Ledger) ConfirmBlock(block *pb.InternalBlock, isRoot bool) ConfirmStatu
 			if parserErr != nil {
 				confirmStatus.Succ = false
 				confirmStatus.Error = parserErr
-			}
-			oldPbBlockBuf, blockErr := l.blocksTable.Get(oldTx.Blockid)
-			if blockErr != nil {
-				confirmStatus.Succ = false
-				confirmStatus.Error = blockErr
+				return confirmStatus
 			}
 			oldBlock := &pb.InternalBlock{}
-			parserErr = proto.Unmarshal(oldPbBlockBuf, oldBlock)
-			if parserErr != nil {
-				confirmStatus.Succ = false
-				confirmStatus.Error = parserErr
+			if cachedBlk, cacheHit := oldBlockCache[string(oldTx.Blockid)]; cacheHit {
+				oldBlock = cachedBlk
+			} else {
+				oldPbBlockBuf, blockErr := l.blocksTable.Get(oldTx.Blockid)
+				if blockErr != nil {
+					confirmStatus.Succ = false
+					confirmStatus.Error = blockErr
+					return confirmStatus
+				}
+				parserErr = proto.Unmarshal(oldPbBlockBuf, oldBlock)
+				if parserErr != nil {
+					confirmStatus.Succ = false
+					confirmStatus.Error = parserErr
+					return confirmStatus
+				}
+				oldBlockCache[string(oldBlock.Blockid)] = oldBlock
 			}
 			if oldBlock.InTrunk && block.InTrunk && oldBlock.Height <= splitHeight {
 				confirmStatus.Succ = false

--- a/core/utxo/async.go
+++ b/core/utxo/async.go
@@ -155,7 +155,7 @@ func (uv *UtxoVM) flushTxList(txList []*pb.Transaction) error {
 			pbTxList[i] = nil
 			continue
 		}
-		doErr := uv.doTxInternal(tx, batch)
+		doErr := uv.doTxInternal(tx, batch, nil)
 		if doErr != nil {
 			uv.xlog.Warn("doTxInternal failed, when DoTx", "doErr", doErr)
 			uv.asyncResult.Send(tx.Txid, doErr)

--- a/core/utxo/spin_lock.go
+++ b/core/utxo/spin_lock.go
@@ -90,6 +90,11 @@ func (sp *SpinLock) ExtractLockKeys(tx *pb.Transaction) []*LockKey {
 	return keys[:lim]
 }
 
+func (sp *SpinLock) IsLocked(key string) bool {
+	_, locked := sp.m.Load(key)
+	return locked
+}
+
 func (sp *SpinLock) TryLock(lockKeys []*LockKey) ([]*LockKey, bool) {
 	succLocked := []*LockKey{}
 	for _, k := range lockKeys {

--- a/core/utxo/spin_lock.go
+++ b/core/utxo/spin_lock.go
@@ -1,0 +1,91 @@
+package utxo
+
+import "sync"
+import "sort"
+import "runtime"
+import "strconv"
+import "github.com/xuperchain/xuperchain/core/pb"
+
+const (
+	SharedLock    = 1 //可共享的情况
+	ExclusiveLock = 2 //互斥的情况
+)
+
+type SpinLock struct {
+	m *sync.Map
+}
+
+type LockKey struct {
+	lockType int
+	key      string
+}
+
+func (lk *LockKey) String() string {
+	if lk.lockType == SharedLock {
+		return lk.key + ":S"
+	} else if lk.lockType == ExclusiveLock {
+		return lk.key + ":X"
+	}
+	return lk.key
+}
+
+func NewSpinLock() *SpinLock {
+	return &SpinLock{m: &sync.Map{}}
+}
+
+func (sp *SpinLock) ExtractLockKeys(tx *pb.Transaction) []*LockKey {
+	keys := []*LockKey{}
+	for _, input := range tx.TxInputs {
+		k := string(input.RefTxid) + "_" + strconv.Itoa(int(input.RefOffset))
+		keys = append(keys, &LockKey{key: k, lockType: ExclusiveLock})
+	}
+	readKeys := map[string]bool{}
+	writeKeys := map[string]bool{}
+	for _, input := range tx.TxInputsExt {
+		k := string(input.Bucket) + "/" + string(input.Key)
+		readKeys[k] = true
+	}
+	for _, output := range tx.TxOutputsExt {
+		k := string(output.Bucket) + "/" + string(output.Key)
+		delete(readKeys, k)
+		writeKeys[k] = true
+	}
+	for k := range readKeys {
+		keys = append(keys, &LockKey{key: k, lockType: SharedLock})
+	}
+	for k := range writeKeys {
+		keys = append(keys, &LockKey{key: k, lockType: ExclusiveLock})
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].key < keys[j].key })
+	lim := 0
+	//dedup
+	for i, k := range keys {
+		if i == 0 || keys[i].key != keys[i-1].key {
+			keys[lim] = k
+			lim++
+		}
+	}
+	return keys[:lim]
+}
+
+func (sp *SpinLock) Lock(lockKeys []*LockKey) {
+	for _, k := range lockKeys {
+		for {
+			if lkType, occupiedByOthers := sp.m.LoadOrStore(k.key, k.lockType); occupiedByOthers {
+				if lkType == SharedLock && k.lockType == SharedLock {
+					break
+				}
+				runtime.Gosched()
+			} else {
+				break
+			}
+		}
+	}
+}
+
+func (sp *SpinLock) Unlock(lockKeys []*LockKey) {
+	N := len(lockKeys)
+	for i := N - 1; i >= 0; i-- {
+		sp.m.Delete(lockKeys[i].key)
+	}
+}

--- a/core/utxo/spin_lock.go
+++ b/core/utxo/spin_lock.go
@@ -57,6 +57,10 @@ func (sp *SpinLock) ExtractLockKeys(tx *pb.Transaction) []*LockKey {
 		k := string(input.RefTxid) + "_" + strconv.Itoa(int(input.RefOffset))
 		keys = append(keys, &LockKey{key: k, lockType: ExclusiveLock})
 	}
+	for offset, _ := range tx.TxOutputs {
+		k := string(tx.Txid) + "_" + strconv.Itoa(offset)
+		keys = append(keys, &LockKey{key: k, lockType: ExclusiveLock})
+	}
 	readKeys := map[string]bool{}
 	writeKeys := map[string]bool{}
 	for _, input := range tx.TxInputsExt {

--- a/core/utxo/spin_lock.go
+++ b/core/utxo/spin_lock.go
@@ -10,8 +10,14 @@ const (
 	ExclusiveLock = 2 //互斥的情况
 )
 
+type RefCounter struct {
+	ctMap map[string]int
+	mu    sync.Mutex
+}
+
 type SpinLock struct {
-	m *sync.Map
+	m          *sync.Map
+	refCounter *RefCounter
 }
 
 type LockKey struct {
@@ -28,8 +34,21 @@ func (lk *LockKey) String() string {
 	return lk.key
 }
 
+func (rc *RefCounter) Add(key string) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.ctMap[key] += 1
+}
+
+func (rc *RefCounter) Release(key string) int {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.ctMap[key] -= 1
+	return rc.ctMap[key]
+}
+
 func NewSpinLock() *SpinLock {
-	return &SpinLock{m: &sync.Map{}}
+	return &SpinLock{m: &sync.Map{}, refCounter: &RefCounter{ctMap: map[string]int{}}}
 }
 
 func (sp *SpinLock) ExtractLockKeys(tx *pb.Transaction) []*LockKey {
@@ -71,14 +90,18 @@ func (sp *SpinLock) TryLock(lockKeys []*LockKey) ([]*LockKey, bool) {
 	succLocked := []*LockKey{}
 	for _, k := range lockKeys {
 		if lkType, occupiedByOthers := sp.m.LoadOrStore(k.key, k.lockType); occupiedByOthers {
-			if lkType == SharedLock && k.lockType == SharedLock {
+			if lkType == SharedLock && k.lockType == SharedLock { //读读共享
+				sp.refCounter.Add(k.key)
 				succLocked = append(succLocked, k)
 				continue
 			} else {
-				return succLocked, false
+				return succLocked, false //读写冲突
 			}
 		}
-		succLocked = append(succLocked, k)
+		if k.lockType == SharedLock {
+			sp.refCounter.Add(k.key)
+		}
+		succLocked = append(succLocked, k) //第一个抢到
 	}
 	return succLocked, true
 }
@@ -86,6 +109,14 @@ func (sp *SpinLock) TryLock(lockKeys []*LockKey) ([]*LockKey, bool) {
 func (sp *SpinLock) Unlock(lockKeys []*LockKey) {
 	N := len(lockKeys)
 	for i := N - 1; i >= 0; i-- {
-		sp.m.Delete(lockKeys[i].key)
+		lkType := lockKeys[i].lockType
+		k := lockKeys[i].key
+		if lkType == ExclusiveLock {
+			sp.m.Delete(k)
+		} else if lkType == SharedLock { //共享锁要考虑引用计数
+			if sp.refCounter.Release(k) == 0 {
+				sp.m.Delete(lockKeys[i].key)
+			}
+		}
 	}
 }

--- a/core/utxo/spin_lock_test.go
+++ b/core/utxo/spin_lock_test.go
@@ -8,6 +8,7 @@ import "github.com/xuperchain/xuperchain/core/pb"
 func TestSpinLock(t *testing.T) {
 	sp := NewSpinLock()
 	tx1 := &pb.Transaction{
+		Txid: []byte("tx1"),
 		TxInputs: []*pb.TxInput{
 			&pb.TxInput{
 				RefTxid: []byte("tx0"),
@@ -16,6 +17,9 @@ func TestSpinLock(t *testing.T) {
 				RefTxid:   []byte("tx3"),
 				RefOffset: 1,
 			},
+		},
+		TxOutputs: []*pb.TxOutput{
+			&pb.TxOutput{},
 		},
 		TxInputsExt: []*pb.TxInputExt{
 			&pb.TxInputExt{
@@ -47,7 +51,7 @@ func TestSpinLock(t *testing.T) {
 	lockKeys2 := sp.ExtractLockKeys(tx2)
 	t.Log(lockKeys1)
 	t.Log(lockKeys2)
-	if fmt.Sprintf("%v", lockKeys1) != "[bk1/key1:X bk2/key2:S tx0_0:X tx3_1:X]" {
+	if fmt.Sprintf("%v", lockKeys1) != "[bk1/key1:X bk2/key2:S tx0_0:X tx1_0:X tx3_1:X]" {
 		t.Fatal("tx1 lock error")
 	}
 	if fmt.Sprintf("%v", lockKeys2) != "[bk2/key2:S tx3_0:X]" {

--- a/core/utxo/spin_lock_test.go
+++ b/core/utxo/spin_lock_test.go
@@ -63,6 +63,9 @@ func TestSpinLock(t *testing.T) {
 		sp.Unlock(succLks)
 	}()
 	sp.TryLock(lockKeys1)
+	if !sp.IsLocked("tx1_0") {
+		t.Fatal("tx1_0 is expected to be locked")
+	}
 	time.Sleep(1 * time.Second)
 	sp.Unlock(lockKeys1)
 	t.Log("tx1 unlock")

--- a/core/utxo/spin_lock_test.go
+++ b/core/utxo/spin_lock_test.go
@@ -17,6 +17,12 @@ func TestSpinLock(t *testing.T) {
 				RefOffset: 1,
 			},
 		},
+		TxInputsExt: []*pb.TxInputExt{
+			&pb.TxInputExt{
+				Bucket: "bk2",
+				Key:    []byte("key2"),
+			},
+		},
 		TxOutputsExt: []*pb.TxOutputExt{
 			&pb.TxOutputExt{
 				Bucket: "bk1",
@@ -41,7 +47,7 @@ func TestSpinLock(t *testing.T) {
 	lockKeys2 := sp.ExtractLockKeys(tx2)
 	t.Log(lockKeys1)
 	t.Log(lockKeys2)
-	if fmt.Sprintf("%v", lockKeys1) != "[bk1/key1:X tx0_0:X tx3_1:X]" {
+	if fmt.Sprintf("%v", lockKeys1) != "[bk1/key1:X bk2/key2:S tx0_0:X tx3_1:X]" {
 		t.Fatal("tx1 lock error")
 	}
 	if fmt.Sprintf("%v", lockKeys2) != "[bk2/key2:S tx3_0:X]" {
@@ -50,6 +56,7 @@ func TestSpinLock(t *testing.T) {
 	go func() {
 		succLks, ok := sp.TryLock(lockKeys2)
 		t.Log("tx2 got lock", succLks, ok)
+		sp.Unlock(succLks)
 	}()
 	sp.TryLock(lockKeys1)
 	time.Sleep(1 * time.Second)

--- a/core/utxo/spin_lock_test.go
+++ b/core/utxo/spin_lock_test.go
@@ -48,10 +48,10 @@ func TestSpinLock(t *testing.T) {
 		t.Fatal("tx2 lock error")
 	}
 	go func() {
-		sp.Lock(lockKeys2)
-		t.Log("tx2 got lock")
+		succLks, ok := sp.TryLock(lockKeys2)
+		t.Log("tx2 got lock", succLks, ok)
 	}()
-	sp.Lock(lockKeys1)
+	sp.TryLock(lockKeys1)
 	time.Sleep(1 * time.Second)
 	sp.Unlock(lockKeys1)
 	t.Log("tx1 unlock")

--- a/core/utxo/spin_lock_test.go
+++ b/core/utxo/spin_lock_test.go
@@ -1,0 +1,58 @@
+package utxo
+
+import "testing"
+import "time"
+import "fmt"
+import "github.com/xuperchain/xuperchain/core/pb"
+
+func TestSpinLock(t *testing.T) {
+	sp := NewSpinLock()
+	tx1 := &pb.Transaction{
+		TxInputs: []*pb.TxInput{
+			&pb.TxInput{
+				RefTxid: []byte("tx0"),
+			},
+			&pb.TxInput{
+				RefTxid:   []byte("tx3"),
+				RefOffset: 1,
+			},
+		},
+		TxOutputsExt: []*pb.TxOutputExt{
+			&pb.TxOutputExt{
+				Bucket: "bk1",
+				Key:    []byte("key1"),
+			},
+		},
+	}
+	tx2 := &pb.Transaction{
+		TxInputsExt: []*pb.TxInputExt{
+			&pb.TxInputExt{
+				Bucket: "bk2",
+				Key:    []byte("key2"),
+			},
+		},
+		TxInputs: []*pb.TxInput{
+			&pb.TxInput{
+				RefTxid: []byte("tx3"),
+			},
+		},
+	}
+	lockKeys1 := sp.ExtractLockKeys(tx1)
+	lockKeys2 := sp.ExtractLockKeys(tx2)
+	t.Log(lockKeys1)
+	t.Log(lockKeys2)
+	if fmt.Sprintf("%v", lockKeys1) != "[bk1/key1:X tx0_0:X tx3_1:X]" {
+		t.Fatal("tx1 lock error")
+	}
+	if fmt.Sprintf("%v", lockKeys2) != "[bk2/key2:S tx3_0:X]" {
+		t.Fatal("tx2 lock error")
+	}
+	go func() {
+		sp.Lock(lockKeys2)
+		t.Log("tx2 got lock")
+	}()
+	sp.Lock(lockKeys1)
+	time.Sleep(1 * time.Second)
+	sp.Unlock(lockKeys1)
+	t.Log("tx1 unlock")
+}

--- a/core/utxo/tx_verification.go
+++ b/core/utxo/tx_verification.go
@@ -117,7 +117,6 @@ func (uv *UtxoVM) ImmediateVerifyTx(tx *pb.Transaction, isRootTx bool) (bool, er
 			uv.xlog.Warn("ImmediateVerifyTx: verifyRWSetPermission failed", "error", err)
 			return ok, ErrACLNotEnough
 		}
-
 		// verify RWSet(run contracts and compare RWSet)
 		ok, err = uv.verifyTxRWSets(tx)
 		if err != nil {

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -1287,7 +1287,7 @@ func (uv *UtxoVM) doTxSync(tx *pb.Transaction) error {
 	succLockKeys, lockOK := uv.spLock.TryLock(spLockKeys)
 	defer uv.spLock.Unlock(succLockKeys)
 	if !lockOK {
-		uv.xlog.Warn("failed to lock", "keys", spLockKeys)
+		uv.xlog.Warn("failed to lock", "txid", global.F(tx.Txid))
 		return ErrDoubleSpent
 	}
 	waitTime := time.Now().Unix() - recvTime

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -1514,8 +1514,8 @@ func (uv *UtxoVM) processUnconfirmTxs(block *pb.InternalBlock, batch kvdb.Batch,
 				return
 			}
 			limit := len(sortTxList)
-			if limit > OfflineTxChanBuffer {
-				limit = OfflineTxChanBuffer / 2
+			if limit > OfflineTxChanBuffer/3 {
+				limit = OfflineTxChanBuffer / 3
 			}
 			for _, txid := range sortTxList[:limit] {
 				if txidsInBlock[txid] || undoDone[txid] {

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -1287,7 +1287,7 @@ func (uv *UtxoVM) doTxSync(tx *pb.Transaction) error {
 	succLockKeys, lockOK := uv.spLock.TryLock(spLockKeys)
 	defer uv.spLock.Unlock(succLockKeys)
 	if !lockOK {
-		uv.xlog.Warn("failed to lock", spLockKeys)
+		uv.xlog.Warn("failed to lock", "keys", spLockKeys)
 		return ErrDoubleSpent
 	}
 	waitTime := time.Now().Unix() - recvTime

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -1514,8 +1514,8 @@ func (uv *UtxoVM) processUnconfirmTxs(block *pb.InternalBlock, batch kvdb.Batch,
 				return
 			}
 			limit := len(sortTxList)
-			if limit > OfflineTxChanBuffer/3 {
-				limit = OfflineTxChanBuffer / 3
+			if limit > OfflineTxChanBuffer/2 {
+				limit = OfflineTxChanBuffer / 2
 			}
 			for _, txid := range sortTxList[:limit] {
 				if txidsInBlock[txid] || undoDone[txid] {

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -238,7 +238,7 @@ func (uv *UtxoVM) checkInputEqualOutput(tx *pb.Transaction) error {
 			uBinary, findErr := uv.utxoTable.Get([]byte(utxoKey))
 			if findErr != nil {
 				if common.NormalizedKVError(findErr) == common.ErrKVNotFound {
-					uv.xlog.Warn("not found utxo key:", "utxoKey", utxoKey)
+					uv.xlog.Info("not found utxo key:", "utxoKey", utxoKey)
 					return ErrUTXONotFound
 				}
 				uv.xlog.Warn("unexpected leveldb error when do checkInputEqualOutput", "findErr", findErr)
@@ -1287,7 +1287,7 @@ func (uv *UtxoVM) doTxSync(tx *pb.Transaction) error {
 	succLockKeys, lockOK := uv.spLock.TryLock(spLockKeys)
 	defer uv.spLock.Unlock(succLockKeys)
 	if !lockOK {
-		uv.xlog.Warn("failed to lock", "txid", global.F(tx.Txid))
+		uv.xlog.Info("failed to lock", "txid", global.F(tx.Txid))
 		return ErrDoubleSpent
 	}
 	waitTime := time.Now().Unix() - recvTime
@@ -1302,7 +1302,7 @@ func (uv *UtxoVM) doTxSync(tx *pb.Transaction) error {
 	batch := uv.ldb.NewBatch()
 	doErr := uv.doTxInternal(tx, batch)
 	if doErr != nil {
-		uv.xlog.Warn("doTxInternal failed, when DoTx", "doErr", doErr)
+		uv.xlog.Info("doTxInternal failed, when DoTx", "doErr", doErr)
 		return doErr
 	}
 	batch.Put(append([]byte(pb.UnconfirmedTablePrefix), tx.Txid...), pbTxBuf)

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -1285,9 +1285,8 @@ func (uv *UtxoVM) doTxSync(tx *pb.Transaction) error {
 	defer uv.mutex.RUnlock() //lock guard
 	spLockKeys := uv.spLock.ExtractLockKeys(tx)
 	succLockKeys, lockOK := uv.spLock.TryLock(spLockKeys)
-	if lockOK {
-		defer uv.spLock.Unlock(succLockKeys)
-	} else {
+	defer uv.spLock.Unlock(succLockKeys)
+	if !lockOK {
 		uv.xlog.Warn("failed to lock", spLockKeys)
 		return ErrDoubleSpent
 	}

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -1380,6 +1380,10 @@ func (uv *UtxoVM) DoTx(tx *pb.Transaction) error {
 		uv.xlog.Warn("coinbase tx can not be given by PostTx", "txid", global.F(tx.Txid))
 		return ErrUnexpected
 	}
+	if len(tx.Blockid) > 0 {
+		uv.xlog.Warn("tx from PostTx must not have blockid", "txid", global.F(tx.Txid))
+		return ErrUnexpected
+	}
 	if uv.asyncMode || uv.asyncBlockMode {
 		return uv.doTxAsync(tx)
 	}

--- a/core/utxo/utxo_cache.go
+++ b/core/utxo/utxo_cache.go
@@ -10,6 +10,20 @@ type CacheItem struct {
 	ele *list.Element
 }
 
+type CacheFiller struct {
+	hooks []func()
+}
+
+func (cf *CacheFiller) Commit() {
+	for _, f := range cf.hooks {
+		f()
+	}
+}
+
+func (cf *CacheFiller) Add(f func()) {
+	cf.hooks = append(cf.hooks, f)
+}
+
 // UtxoCache is a in-memory cache of UTXO
 type UtxoCache struct {
 	// <ADDRESS, <UTXO_KEY, UTXO_ITEM>>

--- a/core/xmodel/env.go
+++ b/core/xmodel/env.go
@@ -20,7 +20,13 @@ func (s *XModel) PrepareEnv(tx *pb.Transaction) (*Env, error) {
 	env := &Env{}
 	s.logger.Trace("PrepareEnv", "tx.TxInputsExt", tx.TxInputsExt, "tx.TxOutputsExt", tx.TxOutputsExt)
 	for _, txIn := range tx.TxInputsExt {
-		verData, err := s.GetUncommited(txIn.Bucket, txIn.Key)
+		var verData *xmodel_pb.VersionedData
+		var err error
+		if len(tx.Blockid) == 0 {
+			verData, err = s.Get(txIn.Bucket, txIn.Key)
+		} else {
+			verData, err = s.GetFromLedger(txIn)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/core/xmodel/xmodel.go
+++ b/core/xmodel/xmodel.go
@@ -195,6 +195,9 @@ func (s *XModel) GetUncommited(bucket string, key []byte) (*xmodel_pb.VersionedD
 
 // GetFromLedger get data directely from ledger
 func (s *XModel) GetFromLedger(txin *pb.TxInputExt) (*xmodel_pb.VersionedData, error) {
+	if txin.RefTxid == nil {
+		return s.makeEmptyVersionedData(txin.Bucket, txin.Key), nil
+	}
 	version := MakeVersion(txin.RefTxid, txin.RefOffset)
 	return s.fetchVersionedData(txin.Bucket, version)
 }

--- a/core/xmodel/xmodel.go
+++ b/core/xmodel/xmodel.go
@@ -66,7 +66,9 @@ func (s *XModel) updateExtUtxo(tx *pb.Transaction, batch kvdb.Batch) error {
 			batch.Put(putKey, []byte(valueVersion))
 			s.logger.Trace("    xmodel put", "putkey", string(putKey), "version", valueVersion)
 		}
-		s.batchCache.Store(string(bucketAndKey), valueVersion)
+		if len(tx.Blockid) > 0 {
+			s.batchCache.Store(string(bucketAndKey), valueVersion)
+		}
 		s.bucketCacheStore(txOut.Bucket, valueVersion, &xmodel_pb.VersionedData{
 			RefTxid:   tx.Txid,
 			RefOffset: int32(offset),
@@ -82,7 +84,7 @@ func (s *XModel) updateExtUtxo(tx *pb.Transaction, batch kvdb.Batch) error {
 
 // DoTx running a transaction and update extUtxoTable
 func (s *XModel) DoTx(tx *pb.Transaction, batch kvdb.Batch) error {
-	if tx.Blockid != nil {
+	if len(tx.Blockid) > 0 {
 		s.cleanCache(batch)
 	}
 	err := s.verifyInputs(tx)

--- a/core/xmodel/xmodel.go
+++ b/core/xmodel/xmodel.go
@@ -193,6 +193,12 @@ func (s *XModel) GetUncommited(bucket string, key []byte) (*xmodel_pb.VersionedD
 	return s.Get(bucket, key)
 }
 
+// GetFromLedger get data directely from ledger
+func (s *XModel) GetFromLedger(txin *pb.TxInputExt) (*xmodel_pb.VersionedData, error) {
+	version := MakeVersion(txin.RefTxid, txin.RefOffset)
+	return s.fetchVersionedData(txin.Bucket, version)
+}
+
 // Get get value for specific key, return value with version
 func (s *XModel) Get(bucket string, key []byte) (*xmodel_pb.VersionedData, error) {
 	rawKey := makeRawKey(bucket, key)

--- a/core/xmodel/xmodel.go
+++ b/core/xmodel/xmodel.go
@@ -82,7 +82,9 @@ func (s *XModel) updateExtUtxo(tx *pb.Transaction, batch kvdb.Batch) error {
 
 // DoTx running a transaction and update extUtxoTable
 func (s *XModel) DoTx(tx *pb.Transaction, batch kvdb.Batch) error {
-	s.cleanCache(batch)
+	if tx.Blockid != nil {
+		s.cleanCache(batch)
+	}
 	err := s.verifyInputs(tx)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

What is the purpose of the change?
Improve performance.
Transfer (+49%)
Invoke( +15% )
No OOM

## Type of change

Please delete options that are not relevant.
- [ ] Performance Improvement (non-breaking change which fixes an issue)

## Brief of your solution
make PostTx be processed in parallel. Only the transactions with the same input UTXO or modifying same contract variables be processed sequencially, by the help of a spin lock.

## How Has This Been Tested?
CI
