### PR TITLE
fix memory leak

### DIFF
--- a/core/p2p/p2pv1/conn.go
+++ b/core/p2p/p2pv1/conn.go
@@ -110,7 +110,9 @@ func (c *Conn) newClient(ctx context.Context) (p2p_pb.P2PService_SendP2PMessageC
 
 // SendMessage send message to a peer
 func (c *Conn) SendMessage(ctx context.Context, msg *p2pPb.XuperMessage) error {
-	client, err := c.newClient(ctx)
+	ctxsm, cancel := context.WithCancel(ctx)
+	defer cancel()
+	client, err := c.newClient(ctxsm)
 	if err != nil {
 		c.lg.Error("SendMessage new client error")
 		return err
@@ -123,7 +125,9 @@ func (c *Conn) SendMessage(ctx context.Context, msg *p2pPb.XuperMessage) error {
 
 // SendMessageWithResponse send message to a peer with responce
 func (c *Conn) SendMessageWithResponse(ctx context.Context, msg *p2pPb.XuperMessage) (*p2pPb.XuperMessage, error) {
-	client, err := c.newClient(ctx)
+	ctxsm, cancel := context.WithCancel(ctx)
+	defer cancel()
+	client, err := c.newClient(ctxsm)
 	if err != nil {
 		c.lg.Error("SendMessageWithResponse new client error", err.Error())
 		return nil, err

--- a/core/p2p/p2pv1/conn.go
+++ b/core/p2p/p2pv1/conn.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"io"
 	"io/ioutil"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/xuperchain/log15"
@@ -25,11 +26,12 @@ type Conn struct {
 	certPath    string
 	serviceName string
 	isUseCert   bool
+	timeOut     int64
 	quitCh      chan bool
 }
 
 // NewConn create new connection with addr
-func NewConn(lg log.Logger, addr string, certPath, serviceName string, isUseCert bool, maxMsgSize int) (*Conn, error) {
+func NewConn(lg log.Logger, addr string, certPath, serviceName string, isUseCert bool, maxMsgSize int, timeOut int64) (*Conn, error) {
 	conn := &Conn{
 		id:          addr,
 		lg:          lg,
@@ -110,9 +112,9 @@ func (c *Conn) newClient(ctx context.Context) (p2p_pb.P2PService_SendP2PMessageC
 
 // SendMessage send message to a peer
 func (c *Conn) SendMessage(ctx context.Context, msg *p2pPb.XuperMessage) error {
-	ctxsm, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(c.timeOut)*time.Second)
 	defer cancel()
-	client, err := c.newClient(ctxsm)
+	client, err := c.newClient(ctx)
 	if err != nil {
 		c.lg.Error("SendMessage new client error")
 		return err
@@ -125,9 +127,9 @@ func (c *Conn) SendMessage(ctx context.Context, msg *p2pPb.XuperMessage) error {
 
 // SendMessageWithResponse send message to a peer with responce
 func (c *Conn) SendMessageWithResponse(ctx context.Context, msg *p2pPb.XuperMessage) (*p2pPb.XuperMessage, error) {
-	ctxsm, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(c.timeOut)*time.Second)
 	defer cancel()
-	client, err := c.newClient(ctxsm)
+	client, err := c.newClient(ctx)
 	if err != nil {
 		c.lg.Error("SendMessageWithResponse new client error", err.Error())
 		return nil, err

--- a/core/p2p/p2pv1/conn_pool.go
+++ b/core/p2p/p2pv1/conn_pool.go
@@ -76,7 +76,7 @@ func (cp *ConnPool) Find(addr string) (*Conn, error) {
 	if cp.conns[addr] != nil {
 		return cp.conns[addr], nil
 	}
-	conn, err := NewConn(cp.log, addr, cp.config.CertPath, cp.config.ServiceName, cp.config.IsUseCert, int(cp.config.MaxMessageSize)<<20)
+	conn, err := NewConn(cp.log, addr, cp.config.CertPath, cp.config.ServiceName, cp.config.IsUseCert, int(cp.config.MaxMessageSize)<<20, cp.config.Timeout)
 	if err != nil {
 		cp.log.Error("Find NewConn error")
 		return nil, err

--- a/core/p2p/p2pv1/conn_pool.go
+++ b/core/p2p/p2pv1/conn_pool.go
@@ -52,6 +52,8 @@ func (cp *ConnPool) Update(conn *Conn) error {
 	}
 	cp.lock.Lock()
 	defer cp.lock.Unlock()
+	cp.conns[conn.GetConnID()].Close()
+	delete(cp.conns, conn.GetConnID())
 	cp.conns[conn.GetConnID()] = conn
 	return nil
 }
@@ -64,6 +66,7 @@ func (cp *ConnPool) Remove(conn *Conn) error {
 	}
 	cp.lock.Lock()
 	defer cp.lock.Unlock()
+	cp.conns[conn.GetConnID()].Close()
 	delete(cp.conns, conn.GetConnID())
 	return nil
 }

--- a/core/p2p/p2pv1/server.go
+++ b/core/p2p/p2pv1/server.go
@@ -96,7 +96,7 @@ func (p *P2PServerV1) Init(cfg config.P2PConfig, lg log.Logger, extra map[string
 					continue
 				}
 
-				conn, err := NewConn(lg, peer, cfg.CertPath, cfg.ServiceName, cfg.IsUseCert, (int)(cfg.MaxMessageSize)<<20)
+				conn, err := NewConn(lg, peer, cfg.CertPath, cfg.ServiceName, cfg.IsUseCert, (int)(cfg.MaxMessageSize)<<20, p.config.Timeout)
 				if err != nil {
 					p.log.Warn("p2p connect to peer failed", "peer", peer, "error", err)
 					continue

--- a/core/p2p/pb/server.pb.go
+++ b/core/p2p/pb/server.pb.go
@@ -6,9 +6,10 @@ package xuperp2p
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
## Description

What is the purpose of the change?
The stream of `p2pv1.sendmessage()` may leak as the following reason https://godoc.org/google.golang.org/grpc#ClientConn.NewStream . 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution
Cancel the stream manually.
