### PR TITLE
bugfix: AddEndorsor must fail if the chainName not registered

### DIFF
--- a/core/contractsdk/cpp/example/naming/src/naming.cc
+++ b/core/contractsdk/cpp/example/naming/src/naming.cc
@@ -101,6 +101,11 @@ DEFINE_METHOD(Naming, AddEndorsor) {
     CHECK_ARG(address);
     CHECK_ARG(pub_key);
     CHECK_ARG(host);
+    std::string meta;
+    if (!ctx->get_object(Meta(name), &meta)) {
+        ctx->error("chain name does not exist");
+        return;
+    }
     std::string _;
     if (ctx->get_object(Endorsor(name, address), &_)) {
         ctx->error("endorsor already exists");

--- a/core/contractsdk/cpp/example/naming/test/naming.test.js
+++ b/core/contractsdk/cpp/example/naming/test/naming.test.js
@@ -24,6 +24,8 @@ Test("naming", function (t) {
     })
 
     t.Run("AddEndorsor", function(tt) {
+        r0 = contract.Invoke("AddEndorsor", {"name":"testnet", "address":"foo", "host":"127.0.0.1", "pub_key":"xxx"})
+        assert.equal(r0.Message, "chain name does not exist")
         r1 = contract.Invoke("AddEndorsor", {"name":"mainnet.xuper", "address":"bobfffff", "host":"192.168.8.8:37101", "pub_key":"xxxxx"})
         console.log(r1.Body)
         r2 = contract.Invoke("AddEndorsor", {"name":"mainnet.xuper", "address":"bobfffff", "host":"192.168.9.9:37101", "pub_key":"xxxxx"})


### PR DESCRIPTION
## Description
ChainName must be checked first to make sure it is already regsitered, before adding its endorsors to the list.

Fixes # (issue)
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
UT
