### PR TITLE
fix bft consensus can not work bug

### DIFF
--- a/core/consensus/common/chainedbft/smr/smr.go
+++ b/core/consensus/common/chainedbft/smr/smr.go
@@ -261,7 +261,6 @@ func (s *Smr) ProcessProposal(viewNumber int64, proposalID,
 
 // handleReceivedMsg used to process msg received from network
 func (s *Smr) handleReceivedMsg(msg *p2p_pb.XuperMessage) error {
-	s.slog.Warn("handleReceivedMsg", "lenSubscribeList", len(s.subscribeList))
 	s.slog.Info("handleReceivedMsg receive msg", "logid",
 		msg.GetHeader().GetLogid(), "type", msg.GetHeader().GetType())
 

--- a/core/consensus/tdpos/tdpos.go
+++ b/core/consensus/tdpos/tdpos.go
@@ -576,14 +576,14 @@ func (tp *TDpos) ProcessBeforeMiner(timestamp int64) (map[string]interface{}, bo
 					tp.log.Warn("ProcessBeforeMiner ledger truncate failed", "error", err)
 					return nil, false
 				}
-			}
-		}
 
-		qc, err := tp.bftPaceMaker.CurrentQCHigh([]byte(""))
-		if err != nil {
-			return nil, false
+			}
+			qc, err := tp.bftPaceMaker.CurrentQCHigh([]byte(""))
+			if err != nil || qc == nil {
+				return nil, false
+			}
+			res["quorum_cert"] = qc
 		}
-		res["quorum_cert"] = qc
 	}
 
 	res["type"] = TYPE


### PR DESCRIPTION
## Description

What is the purpose of the change?

The `xpos` consensus can not work after pull request  #721 . This because of the instance of `chained-bft` subscribed twice msg to p2p network. So the `smr` disordered. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
