### PR TITLE
Smart broadcast

### DIFF
--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -73,9 +73,6 @@ var (
 )
 
 const (
-	// MaxReposting max repost times for broadcats
-	MaxReposting = 3000 // tx重试广播的最大批次，过多容易打爆对方的grpc连接数
-
 	TxidCacheGcTime = 180 * time.Second
 
 	// DefaultMessageCacheSize for p2p message

--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -75,9 +75,8 @@ var (
 const (
 	// MaxReposting max repost times for broadcats
 	MaxReposting = 3000 // tx重试广播的最大批次，过多容易打爆对方的grpc连接数
-	// RepostingInterval repost retry interval, ms
-	RepostingInterval = 500 // 重试广播间隔ms
-	TxidCacheGcTime   = 180 * time.Second
+
+	TxidCacheGcTime = 180 * time.Second
 
 	// DefaultMessageCacheSize for p2p message
 	DefaultMessageCacheSize = 1000
@@ -324,8 +323,7 @@ func (xc *XChainCore) Init(bcname string, xlog log.Logger, cfg *config.NodeConfi
 
 //周期repost本地未上链的交易
 func (xc *XChainCore) repostOfflineTx() {
-	batchChan := common.NewBatchChan(MaxReposting, RepostingInterval, xc.Utxovm.OfflineTxChan)
-	for txList := range batchChan.GetQueue() {
+	for txList := range xc.Utxovm.OfflineTxChan {
 		header := &pb.Header{Logid: global.Glogid()}
 		batchTxMsg := &pb.BatchTxs{Header: header}
 		//将txList包装为rpc message

--- a/core/core/xchainmg_net.go
+++ b/core/core/xchainmg_net.go
@@ -310,6 +310,8 @@ func (xm *XChainMG) ProcessBatchTx(batchTx *pb.BatchTxs) (*pb.BatchTxs, error) {
 		_, needRepost, _ := xm.ProcessTx(v)
 		if needRepost {
 			succTxs = append(succTxs, v)
+		} else {
+			break // no need to continue
 		}
 	}
 	batchTx.Txs = succTxs

--- a/core/utxo/topsort.go
+++ b/core/utxo/topsort.go
@@ -1,6 +1,6 @@
 package utxo
 
-// TxGraph 交易依赖关系图
+//交易依赖关系图
 type TxGraph map[string][]string
 
 /*
@@ -8,28 +8,23 @@ type TxGraph map[string][]string
 *  'tx3' --> ['tx1', 'tx2']  tx3依赖了tx1,tx2, 也可以表示反向依赖关系:tx3被tx1,tx2依赖
 *  'tx2' --> ['tx0', 'tx1']
  */
-
-// TopSortDFS 对依赖关系图进行拓扑排序
+//对依赖关系图进行拓扑排序
 // 输入：依赖关系图，就是个map
 // 输出: order: 排序后的有序数组，依赖者排在前面，被依赖的排在后面
 //       cyclic: 如果发现有环形依赖关系则输出这个数组
 //
 // 实现参考： https://rosettacode.org/wiki/Topological_sort#Go
-func TopSortDFS(g TxGraph) (order []string, cycle bool, childDAGsSize []int) {
-	// 统计每个tx的次数(包括被引用以及引用次数)
-	degreeForTx := map[string]int{}
-	headTx := map[string]int{}
-	cyclic := []string{}
-	for k, outputs := range g {
-		degreeForTx[k]++
-		headTx[k]++
+func TopSortDFS(g TxGraph) (order []string, cyclic bool, childDAGSize []int) {
+	reverseG := TxGraph{}
+	for n, outputs := range g {
 		for _, m := range outputs {
-			headTx[m]--
 			if g[m] == nil {
 				g[m] = []string{} //预处理一下，coinbase交易可能没有依赖
-				degreeForTx[m]++
 			}
-			degreeForTx[m]++
+			if reverseG[m] == nil {
+				reverseG[m] = []string{}
+			}
+			reverseG[m] = append(reverseG[m], n)
 		}
 	}
 	L := make([]string, len(g))
@@ -37,13 +32,11 @@ func TopSortDFS(g TxGraph) (order []string, cycle bool, childDAGsSize []int) {
 	temp := map[string]bool{} //临时访问标记
 	perm := map[string]bool{} //永久访问标记
 	var cycleFound bool
-	var cycleStart string
 	var visit func(string)
 	visit = func(n string) {
 		switch {
 		case temp[n]: //临时标记里面有，说明产生环了
 			cycleFound = true
-			cycleStart = n
 			return
 		case perm[n]:
 			return
@@ -52,12 +45,7 @@ func TopSortDFS(g TxGraph) (order []string, cycle bool, childDAGsSize []int) {
 		for _, m := range g[n] {
 			visit(m)
 			if cycleFound {
-				if cycleStart > "" {
-					cyclic = append(cyclic, n)
-					if n == cycleStart {
-						cycleStart = ""
-					}
-				}
+				cyclic = true
 				return
 			}
 		}
@@ -66,48 +54,44 @@ func TopSortDFS(g TxGraph) (order []string, cycle bool, childDAGsSize []int) {
 		i--
 		L[i] = n
 	}
-	// 上一个子DAG对应的起始数组索引
-	lastDAGIdx := len(L)
-	// 当前子DAG对应的tx个数
-	currChildDAGSize := 0
+	subGraphs := [][]string{}
+	marked := map[string]bool{}
+	subG := []string{}
+	var dfs func(string)
+	dfs = func(n string) {
+		if marked[n] {
+			return
+		}
+		marked[n] = true
+		for _, m := range g[n] {
+			dfs(m)
+		}
+		for _, m := range reverseG[n] {
+			dfs(m)
+		}
+		subG = append(subG, n)
+	}
 	for n := range g {
-		if perm[n] || len(g[n]) <= 0 {
+		if marked[n] {
 			continue
 		}
-		if v, ok := headTx[n]; ok && v != 1 {
-			continue
-		}
-		visit(n)
-
-		currChildDAGSize = lastDAGIdx - i
-		childDAGsSize = append(childDAGsSize, currChildDAGSize)
-		lastDAGIdx = i
-
-		if cycleFound {
-			return nil, true, reverse(childDAGsSize)
-		}
+		dfs(n)
+		subGraphs = append(subGraphs, subG)
+		subG = []string{}
 	}
-	leftIdx := 0
-	for k, _ := range degreeForTx {
-		// 将入度和出度为0的tx分离出来
-		// degreeForTx[k] == 1表示tx入度为0
-		// len(g[k])表示tx的出度为0
-		if degreeForTx[k] == 1 && len(g[k]) <= 0 {
-			L[leftIdx] = k
-			leftIdx++
-			childDAGsSize = append(childDAGsSize, 1)
+
+	childDAGSize = make([]int, len(subGraphs))
+	for i, g := range subGraphs {
+		childDAGSize[len(subGraphs)-i-1] = len(g)
+		for _, n := range g {
+			if perm[n] {
+				continue
+			}
+			visit(n)
+			if cycleFound {
+				return nil, cyclic, childDAGSize
+			}
 		}
 	}
-	// 存在环
-	if leftIdx != i {
-		return nil, true, nil
-	}
-	return L, false, reverse(childDAGsSize)
-}
-
-func reverse(list []int) []int {
-	for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
-		list[i], list[j] = list[j], list[i]
-	}
-	return list
+	return L, false, childDAGSize
 }

--- a/core/utxo/topsort.go
+++ b/core/utxo/topsort.go
@@ -3,17 +3,13 @@ package utxo
 //交易依赖关系图
 type TxGraph map[string][]string
 
-/*
-*  说明：
-*  'tx3' --> ['tx1', 'tx2']  tx3依赖了tx1,tx2, 也可以表示反向依赖关系:tx3被tx1,tx2依赖
-*  'tx2' --> ['tx0', 'tx1']
- */
-//对依赖关系图进行拓扑排序
+//TopSortDFS 对依赖关系图进行拓扑排序
 // 输入：依赖关系图，就是个map
 // 输出: order: 排序后的有序数组，依赖者排在前面，被依赖的排在后面
 //       cyclic: 如果发现有环形依赖关系则输出这个数组
 //
 // 实现参考： https://rosettacode.org/wiki/Topological_sort#Go
+// 在我们映射中，RefTx是边的源点
 func TopSortDFS(g TxGraph) (order []string, cyclic bool, childDAGSize []int) {
 	reverseG := TxGraph{}
 	for n, outputs := range g {
@@ -71,6 +67,7 @@ func TopSortDFS(g TxGraph) (order []string, cyclic bool, childDAGSize []int) {
 		}
 		subG = append(subG, n)
 	}
+	// dfs变量切分出多个连通的子图
 	for n := range g {
 		if marked[n] {
 			continue
@@ -82,6 +79,7 @@ func TopSortDFS(g TxGraph) (order []string, cyclic bool, childDAGSize []int) {
 
 	childDAGSize = make([]int, len(subGraphs))
 	for i, g := range subGraphs {
+		//记录每个DAG子图的大小
 		childDAGSize[len(subGraphs)-i-1] = len(g)
 		for _, n := range g {
 			if perm[n] {

--- a/core/utxo/topsort_test.go
+++ b/core/utxo/topsort_test.go
@@ -101,7 +101,6 @@ func TestTopSortWithoutCircleCase1(t *testing.T) {
 		for _, v := range currChildStr {
 			tmpStr += v
 		}
-
 		childDAGSlice = append(childDAGSlice, tmpStr)
 		start = end
 		idx++
@@ -126,30 +125,6 @@ func TestTopSortWithoutCircleCase2(t *testing.T) {
 	if circle || len(order) != 6 || len(childDAG) != 2 {
 		t.Error("TestTopSortWithoutCircle error")
 	}
-	childDAGSlice := []string{}
-	// 按照childDAG拆分出多个子DAG字符串
-	idx := 0
-	start, end, length := 0, 0, len(childDAG)
-	for idx < length {
-		end += childDAG[idx]
-		currChildStr := getStr(start, end, order)
-		tmpStr := ""
-		for _, v := range currChildStr {
-			tmpStr += v
-		}
-
-		childDAGSlice = append(childDAGSlice, tmpStr)
-		start = end
-		idx++
-	}
-	sort.Strings(childDAGSlice)
-	orderStr := ""
-	for _, str := range childDAGSlice {
-		orderStr += str
-	}
-	if orderStr != "tx3tx2tx1tx4tx6tx5" {
-		t.Error("TestTopSortWithoutCircle error")
-	}
 }
 
 // 无环 + case3
@@ -165,32 +140,20 @@ func TestTopSortWithoutCircleCase3(t *testing.T) {
 	t.Log("order->", order)
 	t.Log("circle->", circle)
 	t.Log("childDAG->", childDAG)
-	childDAGSlice := []string{}
-	// 按照childDAG拆分出多个子DAG字符串
-	idx := 0
-	start, end, length := 0, 0, len(childDAG)
-	for idx < length {
-		end = start + childDAG[idx]
-		currChildStr := getStr(start, end, order)
-		tmpStr := ""
-		for _, v := range currChildStr {
-			tmpStr += v
-		}
-
-		childDAGSlice = append(childDAGSlice, tmpStr)
-		start = end
-		idx++
+	oo := map[string]int{}
+	for idx, tx := range order {
+		oo[tx] = idx
 	}
-	sort.Strings(childDAGSlice)
-	orderStr := ""
-	for _, str := range childDAGSlice {
-		orderStr += str
-	}
-	t.Log("orderStr->", orderStr)
-	if orderStr != "tx3tx2tx1tx4tx6tx5tx7" {
-		t.Error("TestTopSortWithoutCircle error")
+	if oo["tx3"] < oo["tx1"] &&
+		oo["tx3"] < oo["tx2"] &&
+		oo["tx4"] < oo["tx5"] &&
+		oo["tx4"] < oo["tx6"] {
+		t.Log("order ok")
+	} else {
+		t.Error("order check failed at TestTopSortWithoutCircleCase3")
 	}
 }
+
 func getStr(start int, end int, order []string) []string {
 	fmt.Println("getStr->", "start->", start, " end->", end)
 	ret := []string{}
@@ -199,4 +162,21 @@ func getStr(start int, end int, order []string) []string {
 	}
 
 	return ret
+}
+
+func TestTopSortWithoutCircleCase4(t *testing.T) {
+	graph := map[string][]string{}
+	graph["tx1"] = []string{"tx2"}
+	graph["tx2"] = []string{"tx3"}
+	graph["tx3"] = []string{"tx4"}
+	graph["tx4"] = []string{"tx5"}
+	graph["tx6"] = []string{"tx3"}
+
+	order, circle, childDAG := TopSortDFS(graph)
+	if circle || len(order) != 6 || len(childDAG) != 1 {
+		t.Error("TestTopSortWithoutCircle error")
+	}
+	t.Log("order->", order)
+	t.Log("circle->", circle)
+	t.Log("childDAG->", childDAG)
 }

--- a/core/utxo/utxo.go
+++ b/core/utxo/utxo.go
@@ -121,7 +121,7 @@ type UtxoVM struct {
 	metaTable         kvdb.Database            // 元数据表，会持久化保存latestBlockid
 	withdrawTable     kvdb.Database            // 平行币赎回表, 记录已经赎回的destroy proof
 	smartContract     *contract.SmartContract  // 智能合约执行机
-	OfflineTxChan     chan *pb.Transaction     // 未确认tx的通知chan
+	OfflineTxChan     chan []*pb.Transaction   // 未确认tx的通知chan
 	prevFoundKeyCache *common.LRUCache         // 上一次找到的可用utxo key，用于加速GenerateTx
 	utxoTotal         *big.Int                 // 总资产
 	cryptoClient      crypto_base.CryptoClient // 加密实例
@@ -415,7 +415,7 @@ func MakeUtxoVM(bcname string, ledger *ledger_pkg.Ledger, storePath string, priv
 		utxoCache:         NewUtxoCache(cachesize),
 		smartContract:     contract.NewSmartContract(),
 		vatHandler:        vat.NewVATHandler(),
-		OfflineTxChan:     make(chan *pb.Transaction, OfflineTxChanBuffer),
+		OfflineTxChan:     make(chan []*pb.Transaction, OfflineTxChanBuffer),
 		prevFoundKeyCache: common.NewLRUCache(cachesize),
 		utxoTotal:         big.NewInt(0),
 		minerAddress:      address,
@@ -1540,21 +1540,26 @@ func (uv *UtxoVM) processUnconfirmTxs(block *pb.InternalBlock, batch kvdb.Batch,
 	}
 	if needRepost {
 		go func() {
-			sortTxList, unexpectedCyclic, _ := TopSortDFS(unconfirmTxGraph)
+			sortTxList, unexpectedCyclic, dagSizeList := TopSortDFS(unconfirmTxGraph)
 			if unexpectedCyclic {
 				uv.xlog.Warn("transaction conflicted", "unexpectedCyclic", unexpectedCyclic)
 				return
 			}
-			limit := len(sortTxList)
-			if limit > OfflineTxChanBuffer/2 {
-				limit = OfflineTxChanBuffer / 2
-			}
-			for _, txid := range sortTxList[:limit] {
-				if txidsInBlock[txid] || undoDone[txid] {
-					continue
+			dagNo := 0
+			uv.xlog.Info("parallel group of reposting", "dagGroupEach", dagSizeList)
+			for start := 0; start < len(sortTxList); {
+				dagsize := dagSizeList[dagNo]
+				batchTx := []*pb.Transaction{}
+				for _, txid := range sortTxList[start : start+dagsize] {
+					if txidsInBlock[txid] || undoDone[txid] {
+						continue
+					}
+					offlineTx := unconfirmTxMap[txid]
+					batchTx = append(batchTx, offlineTx)
 				}
-				offlineTx := unconfirmTxMap[txid]
-				uv.OfflineTxChan <- offlineTx
+				uv.OfflineTxChan <- batchTx
+				start += dagsize
+				dagNo++
 			}
 		}()
 	}


### PR DESCRIPTION
## Description
A fullnode have to broadcast local unconfirmed transactions to the network periodly. Before, our broadcast logic was very extensive and disordered, which led to low efficiency of broadcasting. This PR improves broadcast efficiency by using DAG parallel group.

## Type of change

Please delete options that are not relevant.

- [ ] Performance improvement (non-breaking change which fixes an issue)

# Brief of your solution
Dived the unconfirmed-tx-list into serveral DAG subgraph, and then dispatch a message sender thread for each DAG. For each sender, an array of transactions in toplogical order is prepared and sent to other nodes.

```
+------------------------------+
|                              |
|             +----+           |                                    BatchTx 1
|             | Tx3<-----+     |
|             +----+     |     |                      +--------------------------------+
|                        |     |                      |                                |
|   +----+    +----+   +-+--+  |                      |  +---+  +----+  +----+ +----+  |
|   | Tx1+<---+ Tx2+<--+ Tx4|  |                      |  |Tx1|  | Tx2|  |Tx3 | | Tx4|  |
|   +----+    +----+   +----+  |                      |  +---+  +----+  +----+ +----+  |
|                              |         DAG Split    +--------------------------------+
|                              +-------------------->
|   +----+     +----+          |
|   | Tx5<-----+ Tx6|          |                                      BatchTx2
|   +--+-+     +----+          |                      +--------------------------------+
|      ^                       |                      |  +----+    +----+   +-----+    |
|      |       +----+          |                      |  | Tx5|    |Tx6 |   | Tx7 |    |
|      +-------+ Tx7|          |                      |  +----+    +----+   +-----+    |
|              +----+          |                      |                                |
|                              |                      +--------------------------------+
|   Unconfirmed Transactions   |
|                              |
+------------------------------+
```

## How Has This Been Tested?
UT & CI & XBench (+350% confirm speed)
