### PR TITLE
contractsdk/cpp: add compatibility for build.sh

### DIFF
--- a/core/contractsdk/cpp/build.sh
+++ b/core/contractsdk/cpp/build.sh
@@ -2,8 +2,20 @@
 
 cd `dirname $0`
 export PATH=`pwd`/../../../output/:$PATH
+export XDEV_ROOT=`pwd`
 
 # install docker in precondition
+if ! command -v docker &>/dev/null; then
+    echo "missing docker command, please install docker first."
+    exit 1
+fi
+
+# check if xdev available
+if ! command -v xdev &>/dev/null; then
+    project_root=$(cd ../../.. && pwd)
+    echo "missing xdev command, please cd ${project_root} && make"
+    exit 1
+fi
 
 # build examples
 mkdir -p build

--- a/core/contractsdk/cpp/build.sh
+++ b/core/contractsdk/cpp/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 cd `dirname $0`
+export PATH=`pwd`/../../../output/:$PATH
+
 # install docker in precondition
 
 # build examples


### PR DESCRIPTION
## Description

Users can use build.sh to compile contracts as before.