### PR TITLE
Fix the bug of pause growth of XPOS consensus block while init or after upgrade

### DIFF
--- a/core/consensus/common/chainedbft/smr/safety_rules.go
+++ b/core/consensus/common/chainedbft/smr/safety_rules.go
@@ -44,11 +44,11 @@ func (s *Smr) IsQuorumCertValidate(justify *pb.QuorumCert) (bool, error) {
 	justifySigns := justify.GetSignInfos().GetQCSignInfos()
 	// verify justify sign
 	s.slog.Info("IsQuorumCertValidate verify justify sign", "view", justify.GetViewNumber(), "vscView", s.vscView)
-	ok, err := s.verifyVotes(justifySigns, s.preValidates, justify.GetProposalId())
-	if err == ErrVerifyVoteSign || err == ErrJustifySignNotEnough || ok {
-		return ok, err
+	ok, _ := s.verifyVotes(justifySigns, s.validates, justify.GetProposalId())
+	if !ok {
+		return s.verifyVotes(justifySigns, s.preValidates, justify.GetProposalId())
 	}
-	return s.verifyVotes(justifySigns, s.validates, justify.GetProposalId())
+	return true, nil
 }
 
 // verifyVotes verify QC sign

--- a/core/consensus/common/chainedbft/smr/safety_rules.go
+++ b/core/consensus/common/chainedbft/smr/safety_rules.go
@@ -44,8 +44,9 @@ func (s *Smr) IsQuorumCertValidate(justify *pb.QuorumCert) (bool, error) {
 	justifySigns := justify.GetSignInfos().GetQCSignInfos()
 	// verify justify sign
 	s.slog.Info("IsQuorumCertValidate verify justify sign", "view", justify.GetViewNumber(), "vscView", s.vscView)
-	if justify.GetViewNumber() <= s.vscView {
-		return s.verifyVotes(justifySigns, s.preValidates, justify.GetProposalId())
+	ok, err := s.verifyVotes(justifySigns, s.preValidates, justify.GetProposalId())
+	if err == ErrVerifyVoteSign || err == ErrJustifySignNotEnough || ok {
+		return ok, err
 	}
 	return s.verifyVotes(justifySigns, s.validates, justify.GetProposalId())
 }

--- a/core/consensus/common/chainedbft/smr/smr.go
+++ b/core/consensus/common/chainedbft/smr/smr.go
@@ -34,6 +34,8 @@ var (
 	ErrJustifySignNotEnough = errors.New("proposal justify sign not enough error")
 	// ErrVerifyVoteSign return verify vote sign error
 	ErrVerifyVoteSign = errors.New("verify justify sign error")
+	// ErrVerifyVote return verify vote error
+	ErrVerifyVote = errors.New("verify justify error")
 	// ErrInValidateSets return in validate sets error
 	ErrInValidateSets = errors.New("in validate sets error")
 	// ErrCheckDataSum return check data sum error

--- a/core/consensus/common/chainedbft/smr/smr.go
+++ b/core/consensus/common/chainedbft/smr/smr.go
@@ -34,8 +34,6 @@ var (
 	ErrJustifySignNotEnough = errors.New("proposal justify sign not enough error")
 	// ErrVerifyVoteSign return verify vote sign error
 	ErrVerifyVoteSign = errors.New("verify justify sign error")
-	// ErrVerifyVote return verify vote error
-	ErrVerifyVote = errors.New("verify justify error")
 	// ErrInValidateSets return in validate sets error
 	ErrInValidateSets = errors.New("in validate sets error")
 	// ErrCheckDataSum return check data sum error


### PR DESCRIPTION
## Description

What is the purpose of the change?

Fix the bug of pause growth of XPOS consensus block while network init or after upgrade some times.  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
