### PR TITLE
fix verify merkletree when receive block #776

### DIFF
--- a/core/consensus/common/chainedbft/smr/safety_rules.go
+++ b/core/consensus/common/chainedbft/smr/safety_rules.go
@@ -44,10 +44,11 @@ func (s *Smr) IsQuorumCertValidate(justify *pb.QuorumCert) (bool, error) {
 	justifySigns := justify.GetSignInfos().GetQCSignInfos()
 	// verify justify sign
 	s.slog.Info("IsQuorumCertValidate verify justify sign", "view", justify.GetViewNumber(), "vscView", s.vscView)
-	if justify.GetViewNumber() <= s.vscView {
+	ok, _ := s.verifyVotes(justifySigns, s.validates, justify.GetProposalId())
+	if !ok {
 		return s.verifyVotes(justifySigns, s.preValidates, justify.GetProposalId())
 	}
-	return s.verifyVotes(justifySigns, s.validates, justify.GetProposalId())
+	return true, nil
 }
 
 // verifyVotes verify QC sign

--- a/core/consensus/pow/pow.go
+++ b/core/consensus/pow/pow.go
@@ -143,7 +143,6 @@ func (pc *PowConsensus) CompeteMaster(height int64) (bool, bool) {
 // CheckMinerMatch is the specific implementation of ConsensusInterface
 func (pc *PowConsensus) CheckMinerMatch(header *pb.Header, in *pb.InternalBlock) (bool, error) {
 
-
 	blkid, err := ledger.MakeBlockID(in)
 	if err != nil {
 		pc.log.Warn("MakeBlockID error", "logid", header.Logid, "error", err)
@@ -155,11 +154,10 @@ func (pc *PowConsensus) CheckMinerMatch(header *pb.Header, in *pb.InternalBlock)
 	}
 
 	errv := ledger.VerifyMerkle(in)
-	if errv !=nil {
+	if errv != nil {
 		pc.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", errv)
 		return false, nil
 	}
-
 
 	targetBits := pc.calDifficulty(in)
 	if targetBits != in.TargetBits {

--- a/core/consensus/pow/pow.go
+++ b/core/consensus/pow/pow.go
@@ -142,11 +142,7 @@ func (pc *PowConsensus) CompeteMaster(height int64) (bool, bool) {
 
 // CheckMinerMatch is the specific implementation of ConsensusInterface
 func (pc *PowConsensus) CheckMinerMatch(header *pb.Header, in *pb.InternalBlock) (bool, error) {
-	err := ledger.VerifyMerkle(in)
-	if err !=nil {
-		pc.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", err)
-		return false, nil
-	}
+
 
 	blkid, err := ledger.MakeBlockID(in)
 	if err != nil {
@@ -157,6 +153,13 @@ func (pc *PowConsensus) CheckMinerMatch(header *pb.Header, in *pb.InternalBlock)
 		pc.log.Warn("equal blockid error", "logid", header.Logid, "redo blockid", global.F(blkid), "get blockid", global.F(in.Blockid))
 		return false, nil
 	}
+
+	errv := ledger.VerifyMerkle(in)
+	if errv !=nil {
+		pc.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", errv)
+		return false, nil
+	}
+
 
 	targetBits := pc.calDifficulty(in)
 	if targetBits != in.TargetBits {

--- a/core/consensus/pow/pow.go
+++ b/core/consensus/pow/pow.go
@@ -142,6 +142,12 @@ func (pc *PowConsensus) CompeteMaster(height int64) (bool, bool) {
 
 // CheckMinerMatch is the specific implementation of ConsensusInterface
 func (pc *PowConsensus) CheckMinerMatch(header *pb.Header, in *pb.InternalBlock) (bool, error) {
+	err := ledger.VerifyMerkle(in)
+	if err !=nil {
+		pc.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", err)
+		return false, nil
+	}
+
 	blkid, err := ledger.MakeBlockID(in)
 	if err != nil {
 		pc.log.Warn("MakeBlockID error", "logid", header.Logid, "error", err)

--- a/core/consensus/single/singleconsenus.go
+++ b/core/consensus/single/singleconsenus.go
@@ -138,7 +138,7 @@ func (sc *SingleConsensus) CheckMinerMatch(header *pb.Header, in *pb.InternalBlo
 	}
 
 	errv := ledger.VerifyMerkle(in)
-	if errv !=nil {
+	if errv != nil {
 		sc.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", errv)
 		return false, nil
 	}

--- a/core/consensus/single/singleconsenus.go
+++ b/core/consensus/single/singleconsenus.go
@@ -126,11 +126,6 @@ Again:
 
 // CheckMinerMatch is the specific implementation of ConsensusInterface
 func (sc *SingleConsensus) CheckMinerMatch(header *pb.Header, in *pb.InternalBlock) (bool, error) {
-	err := ledger.VerifyMerkle(in)
-	if err !=nil {
-		sc.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", err)
-		return false, nil
-	}
 
 	blkid, err := ledger.MakeBlockID(in)
 	if err != nil {
@@ -141,6 +136,13 @@ func (sc *SingleConsensus) CheckMinerMatch(header *pb.Header, in *pb.InternalBlo
 		sc.log.Warn("equal blockid error", "logid", header.Logid, "redo blockid", global.F(blkid), "get blockid", global.F(in.Blockid), "in.proposer", global.F(in.Proposer), "proposer", global.F(sc.masterAddr))
 		return false, nil
 	}
+
+	errv := ledger.VerifyMerkle(in)
+	if errv !=nil {
+		sc.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", errv)
+		return false, nil
+	}
+
 	//验证签名
 	//1 验证一下签名和公钥是不是能对上
 	k, err := sc.cryptoClient.GetEcdsaPublicKeyFromJSON(in.Pubkey)

--- a/core/consensus/single/singleconsenus.go
+++ b/core/consensus/single/singleconsenus.go
@@ -126,6 +126,12 @@ Again:
 
 // CheckMinerMatch is the specific implementation of ConsensusInterface
 func (sc *SingleConsensus) CheckMinerMatch(header *pb.Header, in *pb.InternalBlock) (bool, error) {
+	err := ledger.VerifyMerkle(in)
+	if err !=nil {
+		sc.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", err)
+		return false, nil
+	}
+
 	blkid, err := ledger.MakeBlockID(in)
 	if err != nil {
 		sc.log.Warn("MakeBlockID error", "logid", header.Logid, "error", err)

--- a/core/consensus/tdpos/tdpos.go
+++ b/core/consensus/tdpos/tdpos.go
@@ -457,15 +457,6 @@ func (tp *TDpos) CheckMinerMatch(header *pb.Header, in *pb.InternalBlock) (bool,
 		return false, nil
 	}
 	// 1 验证块信息是否合法
-	tp.log.Info("Verify block info ")
-	err := ledger.VerifyMerkle(in)
-	tp.log.Info("Verify merkle tree ,blockid: "+global.F(in.Blockid)+", merkleroot:"+global.F(in.MerkleRoot))
-	if err !=nil {
-		tp.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", err)
-		return false, nil
-	}
-
-
 	blkid, err := ledger.MakeBlockID(in)
 	if err != nil {
 		tp.log.Warn("CheckMinerMatch MakeBlockID error", "logid", header.Logid, "error", err)
@@ -474,6 +465,12 @@ func (tp *TDpos) CheckMinerMatch(header *pb.Header, in *pb.InternalBlock) (bool,
 	if !(bytes.Equal(blkid, in.Blockid)) {
 		tp.log.Warn("CheckMinerMatch equal blockid error", "logid", header.Logid, "redo blockid", global.F(blkid),
 			"get blockid", global.F(in.Blockid))
+		return false, nil
+	}
+
+	errv := ledger.VerifyMerkle(in)
+	if errv !=nil {
+		tp.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", errv)
 		return false, nil
 	}
 

--- a/core/consensus/tdpos/tdpos.go
+++ b/core/consensus/tdpos/tdpos.go
@@ -469,7 +469,7 @@ func (tp *TDpos) CheckMinerMatch(header *pb.Header, in *pb.InternalBlock) (bool,
 	}
 
 	errv := ledger.VerifyMerkle(in)
-	if errv !=nil {
+	if errv != nil {
 		tp.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", errv)
 		return false, nil
 	}

--- a/core/consensus/tdpos/tdpos.go
+++ b/core/consensus/tdpos/tdpos.go
@@ -457,6 +457,15 @@ func (tp *TDpos) CheckMinerMatch(header *pb.Header, in *pb.InternalBlock) (bool,
 		return false, nil
 	}
 	// 1 验证块信息是否合法
+	tp.log.Info("Verify block info ")
+	err := ledger.VerifyMerkle(in)
+	tp.log.Info("Verify merkle tree ,blockid: "+global.F(in.Blockid)+", merkleroot:"+global.F(in.MerkleRoot))
+	if err !=nil {
+		tp.log.Warn("VerifyMerkle error", "logid", header.Logid, "error", err)
+		return false, nil
+	}
+
+
 	blkid, err := ledger.MakeBlockID(in)
 	if err != nil {
 		tp.log.Warn("CheckMinerMatch MakeBlockID error", "logid", header.Logid, "error", err)

--- a/core/ledger/ledger_hash.go
+++ b/core/ledger/ledger_hash.go
@@ -108,7 +108,7 @@ func encodeJustify(buf *bytes.Buffer, block *pb.InternalBlock) error {
 }
 
 // VerifyMerkle
-func VerifyMerkle(block *pb.InternalBlock)error{
+func VerifyMerkle(block *pb.InternalBlock) error {
 	blockid := block.Blockid
 	merkleTree := MakeMerkleTree(block.Transactions)
 	if len(merkleTree) > 0 {
@@ -116,15 +116,13 @@ func VerifyMerkle(block *pb.InternalBlock)error{
 		blockMerkleRoot := global.F(block.MerkleRoot)
 		makeMerkleRoot := global.F(merkleRoot)
 		if blockMerkleRoot != makeMerkleRoot {
-			return errors.New("merkle root is wrong, block id:"+global.F(blockid)+",block merkle root:"+blockMerkleRoot+", make merkle root:"+makeMerkleRoot)
+			return errors.New("merkle root is wrong, block id:" + global.F(blockid) + ",block merkle root:" + blockMerkleRoot + ", make merkle root:" + makeMerkleRoot)
 		}
 		return nil
-	}else{
-		return errors.New("can not make merkle tree , block id:"+global.F(blockid))
+	} else {
+		return errors.New("can not make merkle tree , block id:" + global.F(blockid))
 	}
 }
-
-
 
 // MakeBlockID generate BlockID
 func MakeBlockID(block *pb.InternalBlock) ([]byte, error) {

--- a/core/ledger/ledger_hash.go
+++ b/core/ledger/ledger_hash.go
@@ -3,7 +3,9 @@ package ledger
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"github.com/xuperchain/xuperchain/core/global"
 	"math"
 	"sort"
 
@@ -104,6 +106,22 @@ func encodeJustify(buf *bytes.Buffer, block *pb.InternalBlock) error {
 	}
 	return nil
 }
+
+func VerifyMerkle(block *pb.InternalBlock)error{
+	blockid := block.Blockid
+	merkleTree := MakeMerkleTree(block.Transactions)
+	if len(merkleTree) > 0 {
+		merkleRoot := merkleTree[len(merkleTree)-1]
+		if global.F(block.MerkleRoot) != global.F(merkleRoot) {
+			return errors.New("merkle root is wrong, block id:"+global.F(blockid))
+		}
+		return nil
+	}else{
+		return errors.New("can not make merkle tree , block id:"+global.F(blockid))
+	}
+}
+
+
 
 // MakeBlockID generate BlockID
 func MakeBlockID(block *pb.InternalBlock) ([]byte, error) {

--- a/core/ledger/ledger_hash.go
+++ b/core/ledger/ledger_hash.go
@@ -113,10 +113,8 @@ func VerifyMerkle(block *pb.InternalBlock) error {
 	merkleTree := MakeMerkleTree(block.Transactions)
 	if len(merkleTree) > 0 {
 		merkleRoot := merkleTree[len(merkleTree)-1]
-		blockMerkleRoot := global.F(block.MerkleRoot)
-		makeMerkleRoot := global.F(merkleRoot)
-		if blockMerkleRoot != makeMerkleRoot {
-			return errors.New("merkle root is wrong, block id:" + global.F(blockid) + ",block merkle root:" + blockMerkleRoot + ", make merkle root:" + makeMerkleRoot)
+		if !(bytes.Equal(merkleRoot, block.MerkleRoot)) {
+			return errors.New("merkle root is wrong, block id:" + global.F(blockid) + ",block merkle root:" + global.F(block.MerkleRoot) + ", make merkle root:" + global.F(merkleRoot))
 		}
 		return nil
 	} else {

--- a/core/ledger/ledger_hash.go
+++ b/core/ledger/ledger_hash.go
@@ -107,13 +107,16 @@ func encodeJustify(buf *bytes.Buffer, block *pb.InternalBlock) error {
 	return nil
 }
 
+// VerifyMerkle
 func VerifyMerkle(block *pb.InternalBlock)error{
 	blockid := block.Blockid
 	merkleTree := MakeMerkleTree(block.Transactions)
 	if len(merkleTree) > 0 {
 		merkleRoot := merkleTree[len(merkleTree)-1]
-		if global.F(block.MerkleRoot) != global.F(merkleRoot) {
-			return errors.New("merkle root is wrong, block id:"+global.F(blockid))
+		blockMerkleRoot := global.F(block.MerkleRoot)
+		makeMerkleRoot := global.F(merkleRoot)
+		if blockMerkleRoot != makeMerkleRoot {
+			return errors.New("merkle root is wrong, block id:"+global.F(blockid)+",block merkle root:"+blockMerkleRoot+", make merkle root:"+makeMerkleRoot)
 		}
 		return nil
 	}else{


### PR DESCRIPTION
## Description
Fixes #776

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution
add verify merkle root method 

Each consensus plugin CheckMinerMatch method calls the VerifyMerkle method of ledger_hash.go to verify merkleroot
