### PR TITLE
cmd/xdev: compatible with old version of docker command flag

### DIFF
--- a/core/cmd/xdev/internal/mkfile/runner.go
+++ b/core/cmd/xdev/internal/mkfile/runner.go
@@ -87,9 +87,9 @@ func (r *Runner) mountPaths() []string {
 		paths = append(paths, dep.Path)
 	}
 	paths = prefixPaths(paths)
-	mounts := make([]string, 0, len(paths))
+	mounts := make([]string, 0, len(paths)*2)
 	for _, path := range paths {
-		mounts = append(mounts, "-v"+path+":"+path)
+		mounts = append(mounts, "-v", path+":"+path)
 	}
 	return mounts
 }


### PR DESCRIPTION
## Description

Cherry pick fix


