### PR TITLE
cmd/xdev: fix exit code when error

### DIFF
--- a/core/cmd/xdev/internal/cmd/root.go
+++ b/core/cmd/xdev/internal/cmd/root.go
@@ -58,6 +58,9 @@ func SetVersion(ver, date, commit string) {
 
 func Main() {
 	root := rootCommand()
-	root.Execute()
-
+	err := root.Execute()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
 }

--- a/core/cmd/xdev/internal/cmd/test.go
+++ b/core/cmd/xdev/internal/cmd/test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -24,8 +23,7 @@ func newTestCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := c.test(args)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "%s\n", err)
-				os.Exit(-1)
+				return err
 			}
 			return nil
 		},


### PR DESCRIPTION
## Description

Make xdev return a non-zero exit code when error is encountered.