### PR TITLE
Cli UTXO split command support multi signatures

### DIFF
--- a/core/cmd/cli/comm_trans.go
+++ b/core/cmd/cli/comm_trans.go
@@ -121,7 +121,7 @@ func (c *CommTrans) GenPreExeRes(ctx context.Context) (
 			return nil, nil, fmt.Errorf("Get auth require quick error: %s", err.Error())
 		}
 	} else {
-		preExeRPCReq.AuthRequire, err = c.genAuthRequire(c.MultiAddrs)
+		preExeRPCReq.AuthRequire, err = c.GenAuthRequire(c.MultiAddrs)
 		if err != nil {
 			return nil, nil, fmt.Errorf("Get auth require error: %s", err.Error())
 		}
@@ -539,13 +539,13 @@ func (c *CommTrans) GenerateMultisigGenRawTx(ctx context.Context) error {
 	}
 
 	// 填充需要多重签名的addr
-	multiAddrs, err := c.genAuthRequire(c.MultiAddrs)
+	multiAddrs, err := c.GenAuthRequire(c.MultiAddrs)
 	if err != nil {
 		return err
 	}
 	tx.AuthRequire = multiAddrs
 
-	return c.genTxFile(tx)
+	return c.GenTxFile(tx)
 }
 
 func (c *CommTrans) genAuthRequireQuick() ([]string, error) {
@@ -563,7 +563,8 @@ func (c *CommTrans) genAuthRequireQuick() ([]string, error) {
 	return authRequires, nil
 }
 
-func (c *CommTrans) genAuthRequire(filename string) ([]string, error) {
+// GenAuthRequire get auth require aks from file
+func (c *CommTrans) GenAuthRequire(filename string) ([]string, error) {
 	var addrs []string
 
 	fileIn, err := os.Open(filename)
@@ -588,7 +589,8 @@ func (c *CommTrans) genAuthRequire(filename string) ([]string, error) {
 	return addrs, nil
 }
 
-func (c *CommTrans) genTxFile(tx *pb.Transaction) error {
+// GenTxFile generate raw tx file
+func (c *CommTrans) GenTxFile(tx *pb.Transaction) error {
 	data, err := proto.Marshal(tx)
 	if err != nil {
 		return errors.New("Tx marshal error")
@@ -617,6 +619,7 @@ func printTx(tx *pb.Transaction) error {
 	return nil
 }
 
+// GenTxInputsWithMergeUTXO generate tx with merge utxo
 func (c *CommTrans) GenTxInputsWithMergeUTXO(ctx context.Context) ([]*pb.TxInput, *pb.TxOutput, error) {
 	var fromAddr string
 	var err error


### PR DESCRIPTION
## Description

xchain-cli support split address/account's all UTXO into given numbers, but doesn't support generate raw transaction data for multisig command.

For some cases, splitting UTXO need other endorsers' signatures, for example contract account or XuperOS network. This PR add a new option for `utxo split` command to generate raw transaction data so that developers can use `multisig` command to add auth-requires' signatures.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Brief of your solution

Add new options for 'utxo split':

* `-m`: generate raw transaction file;
* `-o`: output file name of the raw transaction;
* `-M`: the file of auth requires' list, default is data/acl/addrs.

Usage example:
```
./xchain-cli utxo split --keys data/keys/ -N 100 -m  --output rawTx.out
./xchain-cli multisig sign --tx ./rawTx.out --output my.sign --keys data/keys/
./xchain-cli multisig sign --tx ./rawTx.out --output other.sign --keys data/testnetkey/
./xchain-cli multisig send my.sign  other.sign --tx ./rawTx.out
```

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
