### PR TITLE
fix bug of txhash calculation

### DIFF
--- a/core/utxo/txhash/txhash.go
+++ b/core/utxo/txhash/txhash.go
@@ -133,7 +133,7 @@ func encodeTxData(tx *pb.Transaction, includeSigns bool) ([]byte, error) {
 			return nil, err
 		}
 		if tx.GetXuperSign() != nil {
-			err = encoder.Encode(tx.AuthRequireSigns)
+			err = encoder.Encode(tx.XuperSign)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Description

XuperSign checked but not used in calculating tx hash.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


