### PR TITLE
Fix vote number verify bug while receive proposal

### DIFF
--- a/core/consensus/common/chainedbft/smr/safety_rules.go
+++ b/core/consensus/common/chainedbft/smr/safety_rules.go
@@ -57,8 +57,8 @@ func (s *Smr) IsQuorumCertValidate(justify *pb.QuorumCert) (bool, error) {
 
 // verifyVotes verify QC sign
 func (s *Smr) verifyVotes(signs []*pb.SignInfo, validateSets []*cons_base.CandidateInfo, proposalID []byte) (bool, error) {
-	s.slog.Trace("verifyVotes", "autual", len(signs), "require", (len(validateSets)-1)*2/3)
-	if len(signs) <= (len(validateSets)-1)*2/3 {
+	s.slog.Trace("verifyVotes", "autual", len(signs), "require", (len(validateSets)+1)*2/3-1)
+	if len(signs) < ((len(validateSets)+1)*2/3 - 1) {
 		return false, ErrJustifySignNotEnough
 	}
 	for _, v := range signs {


### PR DESCRIPTION
## Description

What is the purpose of the change?

The formula of verify vote while receive proposal  have some problem, fix to `len(signs)>=((len(validateSets)+1)*2/3 - 1)` to receive.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
