### PR TITLE
contractsdk/go: show error message when env empty

### DIFF
--- a/core/contractsdk/go/driver/native/driver.go
+++ b/core/contractsdk/go/driver/native/driver.go
@@ -32,6 +32,14 @@ func (d *driver) Serve(contract code.Contract) {
 	chainAddr := os.Getenv(xchainChainAddr)
 	codePort := os.Getenv(xchainCodePort)
 
+	if chainAddr == "" {
+		panic("empty XCHAIN_CHAIN_ADDR env")
+	}
+
+	if codePort == "" {
+		panic("empty XCHAIN_CODE_PORT env")
+	}
+
 	nativeCodeService := newNativeCodeService(chainAddr, contract)
 	rpcServer := grpc.NewServer()
 	pbrpc.RegisterNativeCodeServer(rpcServer, nativeCodeService)


### PR DESCRIPTION
## Description

Prompt friendly information when environment variables are not set.