### PR TITLE
contractsdk/go: fix panic in contract log

### DIFF
--- a/core/contractsdk/cpp/example/counter.cc
+++ b/core/contractsdk/cpp/example/counter.cc
@@ -20,6 +20,7 @@ DEFINE_METHOD(Counter, increase) {
     ctx->get_object(key, &value);
     int cnt = 0;
     cnt = atoi(value.c_str());
+    ctx->logf("get value %s -> %d", key.c_str(), cnt);
     char buf[32];
     snprintf(buf, 32, "%d", cnt + 1);
     ctx->put_object(key, buf);

--- a/core/contractsdk/go/example/counter/counter.go
+++ b/core/contractsdk/go/example/counter/counter.go
@@ -31,6 +31,7 @@ func (c *counter) Increase(ctx code.Context) code.Response {
 	if err == nil {
 		cnt, _ = strconv.Atoi(string(value))
 	}
+	ctx.Logf("get value %s -> %d", key, cnt)
 
 	cntstr := strconv.Itoa(cnt + 1)
 

--- a/core/contractsdk/go/exec/contract_context.go
+++ b/core/contractsdk/go/exec/contract_context.go
@@ -229,7 +229,8 @@ func (c *contractContext) SetOutput(response *code.Response) error {
 func (c *contractContext) Logf(fmtstr string, args ...interface{}) {
 	entry := fmt.Sprintf(fmtstr, args...)
 	request := &pb.PostLogRequest{
-		Entry: entry,
+		Header: &c.header,
+		Entry:  entry,
 	}
 	c.bridgeCallFunc("PostLog", request, new(pb.PostLogResponse))
 }


### PR DESCRIPTION
## Description

What is the purpose of the change?

Missing header field in PostLogRequest


