### PR TITLE
fix compatible issue when upgrade from XPoS

### DIFF
--- a/core/consensus/base/types.go
+++ b/core/consensus/base/types.go
@@ -24,9 +24,9 @@ type ConsensusStatus struct {
 // CandidateInfo define the candidate info
 type CandidateInfo struct {
 	// Address of node
-	Address string `json:"address"`
+	Address string
 	// Neturl of node
-	PeerAddr string `json:"neturl"`
+	PeerAddr string
 }
 
 // CandidateInfoEqual return whether candidate info is equal

--- a/core/consensus/xpoa/xpoa.go
+++ b/core/consensus/xpoa/xpoa.go
@@ -197,11 +197,11 @@ func (xpoa *XPoa) buildXPoaConfig(consCfg map[string]interface{}) error {
 		for idx := 0; idx < len(initProposers); idx++ {
 			p, _ := initProposers[idx].(map[string]interface{})
 			proposer := &cons_base.CandidateInfo{}
-			if p["Address"] == nil || p["PeerAddr"] == nil {
+			if p["address"] == nil || p["neturl"] == nil {
 				return errors.New("Parse XPoa init_proposer error, neturl and address can not be null")
 			}
-			proposer.Address = p["Address"].(string)
-			proposer.PeerAddr = p["PeerAddr"].(string)
+			proposer.Address = p["address"].(string)
+			proposer.PeerAddr = p["neturl"].(string)
 			xpoa.xpoaConf.initProposers = append(xpoa.xpoaConf.initProposers, proposer)
 		}
 	} else {

--- a/core/consensus/xpoa/xpoa.go
+++ b/core/consensus/xpoa/xpoa.go
@@ -197,11 +197,11 @@ func (xpoa *XPoa) buildXPoaConfig(consCfg map[string]interface{}) error {
 		for idx := 0; idx < len(initProposers); idx++ {
 			p, _ := initProposers[idx].(map[string]interface{})
 			proposer := &cons_base.CandidateInfo{}
-			if p["address"] == nil || p["neturl"] == nil {
+			if p["Address"] == nil || p["PeerAddr"] == nil {
 				return errors.New("Parse XPoa init_proposer error, neturl and address can not be null")
 			}
-			proposer.Address = p["address"].(string)
-			proposer.PeerAddr = p["neturl"].(string)
+			proposer.Address = p["Address"].(string)
+			proposer.PeerAddr = p["PeerAddr"].(string)
 			xpoa.xpoaConf.initProposers = append(xpoa.xpoaConf.initProposers, proposer)
 		}
 	} else {

--- a/core/contractsdk/cpp/example/xpoa_validates/src/xpoa_validates.cc
+++ b/core/contractsdk/cpp/example/xpoa_validates/src/xpoa_validates.cc
@@ -48,8 +48,8 @@ DEFINE_METHOD(Hello, initialize) {
     }
     for (int i = 0; i < address_sets.size(); i++) {
         xchain::json j;
-        j["address"] = address_sets[i];
-        j["neturl"] = neturl_sets[i];
+        j["Address"] = address_sets[i];
+        j["PeerAddr"] = neturl_sets[i];
 
         auto data = j.dump();
         std::string old_data;
@@ -81,8 +81,8 @@ DEFINE_METHOD(Hello, add_validate) {
     CHECK_ARG(address);
     CHECK_ARG(neturl);
     xchain::json j;
-    j["address"] = address;
-    j["neturl"] = neturl;
+    j["Address"] = address;
+    j["PeerAddr"] = neturl;
     auto data = j.dump();
 
     std::string old_data;
@@ -144,8 +144,8 @@ DEFINE_METHOD(Hello, update_validate) {
         return;
     }
     xchain::json j;
-    j["address"] = address;
-    j["neturl"] = neturl;
+    j["Address"] = address;
+    j["PeerAddr"] = neturl;
     auto data = j.dump();
 
     if (!ctx->put_object(Validate(address), data)) {

--- a/core/data/config/xpoa.json
+++ b/core/data/config/xpoa.json
@@ -1,48 +1,48 @@
 {
-    "version" : "1"
-    , "predistribution":[
+    "version": "1",
+    "predistribution": [
         {
-            "address" : "f3prTg9itaZY6m48wXXikXdcxiByW7zgk"
-            , "quota" : "100000000000000000000"
+            "address": "f3prTg9itaZY6m48wXXikXdcxiByW7zgk",
+            "quota": "100000000000000000000"
         }
-    ]
-    , "maxblocksize" : "128"
-    , "award" : "1000000"
-    , "decimals" : "8"
-    , "award_decay": {
+    ],
+    "maxblocksize": "128",
+    "award": "1000000",
+    "decimals": "8",
+    "award_decay": {
         "height_gap": 31536000,
         "ratio": 1
-    }
-        , "gas_price": {
+    },
+    "gas_price": {
         "cpu_rate": 1000,
         "mem_rate": 1000000,
         "disk_rate": 1,
         "xfee_rate": 1
-    }
-        , "new_account_resource_amount": 1000
-        , "genesis_consensus":{
+    },
+    "new_account_resource_amount": 1000,
+    "genesis_consensus": {
         "name": "xpoa",
         "config": {
-		"timestamp": "1559021720000000000",
-                "period":"3000",
-                "block_num":"10",
-		"contract_name":"xpoa_validates",
-		"method_name":"get_validates",
-                "init_proposer": [
-       			{		
-            			"address" : "f3prTg9itaZY6m48wXXikXdcxiByW7zgk"
-           			 , "neturl" : "127.0.0.1:47102"
-       			 },
-       			 {
-        			"address" : "U9sKwFmgJVfzgWcfAG47dKn1kLQTqeZN3"
-            			, "neturl" : "127.0.0.1:47103"
-       			 },
-        		{
-        			"address" : "RUEMFGDEnLBpnYYggnXukpVfR9Skm59ph"
-            			, "neturl" : "127.0.0.1:47104"	
-        		}	
-		],
-		"bft_config": {}
-           }
+            "timestamp": "1559021720000000000",
+            "period": "3000",
+            "block_num": "10",
+            "contract_name": "xpoa_validates",
+            "method_name": "get_validates",
+            "init_proposer": [
+                {
+                    "address": "f3prTg9itaZY6m48wXXikXdcxiByW7zgk",
+                    "neturl": "127.0.0.1:47102"
+                },
+                {
+                    "address": "U9sKwFmgJVfzgWcfAG47dKn1kLQTqeZN3",
+                    "neturl": "127.0.0.1:47103"
+                },
+                {
+                    "address": "RUEMFGDEnLBpnYYggnXukpVfR9Skm59ph",
+                    "neturl": "127.0.0.1:47104"
+                }
+            ],
+            "bft_config": {}
         }
+    }
 }


### PR DESCRIPTION
## Description

Issue: after upgrade a blockchain node using XPoS from v3.7 to v3.8, this node could not send vote message to other peers, and the log shows the peer address(neturl) of all validators are empty, so P2P message sent failed. If the network only have 3 validators, since one node cannot give votes, this network will stop produce new block.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Root cause is the json property names of CandidateInfo struct was changed in v3.8, so the solution is to keep CandidateInfo the same as before.

## How Has This Been Tested?

Tested on a 3-nodes network.
