### PR TITLE
Removed unnecessary (multiple redundant) calls to len(), append() etc.

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,11 @@
+version = 1
+
+test_patterns = ["core/test/**/*.go"]
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_paths = ["github.com/chsatyap/xuperchain"]
+  dependencies_vendored = true

--- a/core/event/dispatcher.go
+++ b/core/event/dispatcher.go
@@ -109,7 +109,7 @@ func (e *EventService) Subscribe(stream pb.PubsubService_SubscribeServer,
 }
 
 func StringContains(target string, arr []string) bool {
-	if arr == nil || len(arr) == 0 {
+	if len(arr) == 0 {
 		return false
 	}
 	for i := 0; i < len(arr); i++ {

--- a/core/permission/ptree/ptree.go
+++ b/core/permission/ptree/ptree.go
@@ -132,9 +132,7 @@ func GetPermTreeList(root *PermNode) ([]*PermNode, error) {
 	pn := 0
 	for pn < len(nlist) {
 		if nlist[pn].Children != nil {
-			for _, node := range nlist[pn].Children {
-				nlist = append(nlist, node)
-			}
+			nlist = append(nlist, nlist[pn].Children...)
 		}
 		pn++
 	}

--- a/core/xmodel/dbutils.go
+++ b/core/xmodel/dbutils.go
@@ -41,7 +41,7 @@ func parseRawKey(rawKey []byte) (string, []byte, error) {
 		return "", nil, fmt.Errorf("parseRawKey failed, invalid raw key:%s", string(rawKey))
 	}
 	bucket := string(rawKey[:idx])
-	key := rawKey[idx+1 : len(rawKey)]
+	key := rawKey[idx+1:]
 	return bucket, key, nil
 }
 

--- a/core/xmodel/xmodel_iterator.go
+++ b/core/xmodel/xmodel_iterator.go
@@ -36,7 +36,7 @@ func (di *XMIterator) First() bool {
 func (di *XMIterator) Key() []byte {
 	tablePrefixLen := len(pb.ExtUtxoTablePrefix)
 	kvdbKey := di.iter.Key()
-	return kvdbKey[tablePrefixLen:len(kvdbKey)]
+	return kvdbKey[tablePrefixLen:]
 }
 
 // Error return error info for XMIterator


### PR DESCRIPTION
Overview of the fixes -

1. `len()` returns 0 if the arg is `nil`. So there is no point in checking if the arg is `nil` again.

2.  Collection can be updated using single `append()` call rather than multiple `append()` inside a `for`.

3. Dropping the higher bound in a slice is same as `len(foo`)
`foo[start: ]` is same as `foo[start: len(foo)]`

---

Find the other issues found here - [https://deepsource.io/gh/chsatyap/xuperchain/issues/?category=all](https://deepsource.io/gh/chsatyap/xuperchain/issues/?category=all)

This PR also adds `.deepsource.toml` configuration file to run DeepSource analysis on the repo with. Upon enabling DeepSource, the analysis will run on every PR and commit to detect 560+ types of issues in the changes — including bug risks, anti-patterns, security vulnerabilities, etc.

To enable DeepSource analysis after merging this PR, please follow these steps:
1. [Signup](https://deepsource.io/signup/) on DeepSource with your GitHub account and grant access to this repo.
2. Activate analysis on this repo [here](https://deepsource.io/gh/chsatyap/xuperchain/).
You can also look at the [docs](https://deepsource.io/docs/guides/quickstart.html) for more details.

In case you want me to include any more changes into this PR from the issues that DeepSource has detected or require any changes to this PR, please let me know if I can be of any help!