### PR TITLE
bugfix: panic when closing a nil channel

### DIFF
--- a/core/contract/native/contract_process.go
+++ b/core/contract/native/contract_process.go
@@ -41,13 +41,14 @@ type contractProcess struct {
 
 func newContractProcess(cfg *config.NativeConfig, name, basedir, chainAddr string, desc *xpb.WasmCodeDesc) (*contractProcess, error) {
 	process := &contractProcess{
-		cfg:       cfg,
-		name:      name,
-		basedir:   basedir,
-		binpath:   filepath.Join(basedir, nativeCodeFileName(desc)),
-		chainAddr: chainAddr,
-		desc:      desc,
-		logger:    log.DefaultLogger.New("contract", name),
+		cfg:           cfg,
+		name:          name,
+		basedir:       basedir,
+		binpath:       filepath.Join(basedir, nativeCodeFileName(desc)),
+		chainAddr:     chainAddr,
+		desc:          desc,
+		monitorStopch: make(chan struct{}),
+		logger:        log.DefaultLogger.New("contract", name),
 	}
 	return process, nil
 }


### PR DESCRIPTION
## Description

In native contract process, when close monitor and wait monitor stoped, it will close a nil channel which would cause a panic.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

In goalng, create a channel first before using it.
