### PR TITLE
java contracts sdk: add transferAmount

### DIFF
--- a/core/contractsdk/java/example/builtin-types/README.md
+++ b/core/contractsdk/java/example/builtin-types/README.md
@@ -27,4 +27,6 @@ $ xchain-cli native invoke --method put -a '{"key":"test1","value":"value1"}' bu
 $ xchain-cli native query --method get -a '{"key":"test1"}' builtintypes
 # 迭代器查询
 $ xchain-cli native query --method getList -a '{"start":"test"}' builtintypes
+# invoke调用合约任意方法，并设置--amount会同时转账给合约，转账并打印转账金额
+$ xchain-cli native invoke --method transferAndPrintAmount builtintypes --amount 1 --fee 10
 ```

--- a/core/contractsdk/java/example/builtin-types/src/main/java/com/baidu/xuper/BuiltinTypes.java
+++ b/core/contractsdk/java/example/builtin-types/src/main/java/com/baidu/xuper/BuiltinTypes.java
@@ -82,6 +82,16 @@ public class BuiltinTypes implements Contract {
     }
 
     @ContractMethod
+    public Response transferAndPrintAmount(Context ctx) {
+
+        BigInteger amount = ctx.transferAmount();
+
+        ctx.log("transfer amount: " + amount.toString());
+
+        return Response.ok("ok".getBytes());
+    }
+
+    @ContractMethod
     public Response put(Context ctx) {
         byte[] key = ctx.args().get("key");
         if (key == null) {

--- a/core/contractsdk/java/example/call/README.md
+++ b/core/contractsdk/java/example/call/README.md
@@ -10,17 +10,17 @@
 
 # 部署
 
-`./xchain-cli native deploy --account XC1111111111111113@xuper --fee 15587517 --runtime java c2-0.1.0-jar-with-dependencies.jar --cname c2`
-`./xchain-cli native deploy --account XC1111111111111113@xuper --fee 15587517 --runtime java c1-0.1.0-jar-with-dependencies.jar --cname c1`
+`./xchain-cli native deploy --account XC1111111111111113@xuper --fee 15587517 --runtime java c2-0.1.0-jar-with-dependencies.jar --cname callc2`
+`./xchain-cli native deploy --account XC1111111111111113@xuper --fee 15587517 --runtime java c1-0.1.0-jar-with-dependencies.jar --cname c1call`
 
 成功后会生成合约地址，后续使用这个地址来调用合约
 
 # 调用
 
 ``` bash
-# 转账到c1和c2合约
-$ ./xchain-cli transfer --to c1 --amount 100000
-$ ./xchain-cli transfer --to c2 --amount 100000
+# 转账到c1call和callc2合约
+$ ./xchain-cli transfer --to c1call --amount 100000
+$ ./xchain-cli transfer --to callc2 --amount 100000
 # 跨合约调用
-$ ./xchain-cli native invoke --method invoke -a '{"to":"test"}' c1 --fee 200000
+$ ./xchain-cli native invoke --method invoke -a '{"to":"test"}' c1call --fee 200000
 ```

--- a/core/contractsdk/java/example/call/c1/src/main/java/com/baidu/xuper/c1.java
+++ b/core/contractsdk/java/example/call/c1/src/main/java/com/baidu/xuper/c1.java
@@ -41,7 +41,7 @@ public class c1 implements Contract {
                 };
 
         // 发起跨合约调用
-        Response resp = ctx.call("native", "c2", "invoke", callArgs);
+        Response resp = ctx.call("native", "callc2", "invoke", callArgs);
         // 根据合约调用结果记录到call变量里面并持久化
         ctx.putObject("call".getBytes(), resp.body);
         // 对cnt变量加1并持久化

--- a/core/contractsdk/java/src/main/java/com/baidu/xuper/Context.java
+++ b/core/contractsdk/java/src/main/java/com/baidu/xuper/Context.java
@@ -28,6 +28,8 @@ public interface Context {
 
     public void transfer(String to, BigInteger amount);
 
+    public BigInteger transferAmount();
+
     public Response call(String module, String contract, String method, Map<String, byte[]> args);
 
     public Response crossQuery(String uri, Map<String, byte[]> args);

--- a/core/contractsdk/java/src/main/java/com/baidu/xuper/ContextImpl.java
+++ b/core/contractsdk/java/src/main/java/com/baidu/xuper/ContextImpl.java
@@ -148,6 +148,16 @@ class ContextImpl implements Context {
     }
 
     @Override
+    public BigInteger transferAmount() {
+        BigInteger amount = new BigInteger(this.callArgs.getTransferAmount());
+        if (amount.signum() == -1) {
+            throw new RuntimeException("amount must not be negative");
+        }
+
+        return amount;
+    }
+
+    @Override
     public Response call(String module, String contract, String method, Map<String, byte[]> args) {
         Contract.ContractCallRequest.Builder requestBuild = Contract.ContractCallRequest.newBuilder().setHeader(this.header)
                 .setModule(module).setContract(contract).setMethod(method);


### PR DESCRIPTION
## Description

Java contracts sdk: add transferAmount.
`transferAmount` is used to get token amount when send tokens to a contract. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

It has been tested.
