### PR TITLE
using SM3 for gm address

### DIFF
--- a/core/crypto/client/base/crypto_client_common.go
+++ b/core/crypto/client/base/crypto_client_common.go
@@ -44,26 +44,6 @@ func (*CryptoClientCommon) GetEcdsaPublicKeyJSONFormat(k *ecdsa.PrivateKey) (str
 	return jsonEcdsaPublicKey, err
 }
 
-// GetAddressFromPublicKey 通过公钥来计算地址
-func (*CryptoClientCommon) GetAddressFromPublicKey(pub *ecdsa.PublicKey) (string, error) {
-	address, err := account.GetAddressFromPublicKey(pub)
-	return address, err
-}
-
-// CheckAddressFormat 验证钱包地址是否是合法的格式。
-// 如果成功，返回true和对应的版本号；如果失败，返回false和默认的版本号0
-func (*CryptoClientCommon) CheckAddressFormat(address string) (bool, uint8) {
-	isValid, nVersion := account.CheckAddressFormat(address)
-	return isValid, nVersion
-}
-
-// VerifyAddressUsingPublicKey 验证钱包地址是否和指定的公钥match。
-// 如果成功，返回true和对应的版本号；如果失败，返回false和默认的版本号0
-func (*CryptoClientCommon) VerifyAddressUsingPublicKey(address string, pub *ecdsa.PublicKey) (bool, uint8) {
-	isValid, nVersion := account.VerifyAddressUsingPublicKey(address, pub)
-	return isValid, nVersion
-}
-
 // CryptoClientCommonMultiSig is the default implementation of Multisig interface
 type CryptoClientCommonMultiSig struct{}
 

--- a/core/crypto/client/gm/gmsm/sm2/filekey.go
+++ b/core/crypto/client/gm/gmsm/sm2/filekey.go
@@ -3,6 +3,7 @@ package sm2
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"github.com/xuperchain/xuperchain/core/crypto/client/gm/gmsm/sm3"
 	//	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -287,7 +288,7 @@ func RetrieveAccountByMnemonic(mnemonic string, language int) (*account.ECDSAAcc
 		return nil, err
 	}
 	// 使用公钥来生成钱包地址
-	address, err := account.GetAddressFromPublicKey(&privateKey.PublicKey)
+	address, err := sm3.GetAddressFromPublicKey(&privateKey.PublicKey)
 	if err != nil {
 		return nil, err
 	}
@@ -384,12 +385,48 @@ func GenerateAccountByMnemonic(mnemonic string, language int) (*account.ECDSAAcc
 		return nil, err
 	}
 	// 使用公钥来生成钱包地址
-	address, err := account.GetAddressFromPublicKey(&privateKey.PublicKey)
+	address, err := sm3.GetAddressFromPublicKey(&privateKey.PublicKey)
 	if err != nil {
 		return nil, err
 	}
 	// 返回的字段：助记词、私钥的json、公钥的json、钱包地址、错误信息
 	return &account.ECDSAAccount{nil, mnemonic, jsonPrivateKey, jsonPublicKey, address}, nil
+}
+
+// ExportNewAccount creates new account and export to local file
+func ExportNewAccount(path string, privateKey *ecdsa.PrivateKey) error {
+	jsonPrivateKey, err := account.GetEcdsaPrivateKeyJSONFormat(privateKey)
+	if err != nil {
+		return err
+	}
+	jsonPublicKey, err := account.GetEcdsaPublicKeyJSONFormat(privateKey)
+	if err != nil {
+		return err
+	}
+	address, err := sm3.GetAddressFromPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return err
+	}
+	//如果path不是以/结尾的，自动拼上
+	if strings.LastIndex(path, "/") != len([]rune(path))-1 {
+		path = path + "/"
+	}
+	err = writeFileUsingFilename(path+"private.key", []byte(jsonPrivateKey))
+	if err != nil {
+		log.Printf("Export private key file failed, the err is %v", err)
+		return err
+	}
+	err = writeFileUsingFilename(path+"public.key", []byte(jsonPublicKey))
+	if err != nil {
+		log.Printf("Export public key file failed, the err is %v", err)
+		return err
+	}
+	err = writeFileUsingFilename(path+"address", []byte(address))
+	if err != nil {
+		log.Printf("Export address file failed, the err is %v", err)
+		return err
+	}
+	return err
 }
 
 func ExportNewAccountWithMnemonic(path string, language int, strength uint8, cryptography uint8) error {

--- a/core/crypto/client/gm/gmsm/sm3/address.go
+++ b/core/crypto/client/gm/gmsm/sm3/address.go
@@ -106,7 +106,7 @@ func CheckAddressFormat(address string) (bool, uint8) {
 	simpleCheckCode := slice[len(slice)-4:]
 
 	checkContent := slice[:len(slice)-4]
-	checkCode := hash.DoubleSha256(checkContent)
+	checkCode := Sm3Sum(checkContent)
 	realSimpleCheckCode := checkCode[:4]
 
 	byteVersion := slice[:1]

--- a/core/crypto/client/schnorr/schnorr_crypto_client.go
+++ b/core/crypto/client/schnorr/schnorr_crypto_client.go
@@ -151,6 +151,26 @@ func (xcc SchnorrCryptoClient) GetEcdsaPublicKeyFromJSON(jsonBytes []byte) (*ecd
 	return account.GetEcdsaPublicKeyFromJSON(jsonBytes)
 }
 
+// GetAddressFromPublicKey 通过公钥来计算地址
+func (xcc SchnorrCryptoClient) GetAddressFromPublicKey(pub *ecdsa.PublicKey) (string, error) {
+	address, err := account.GetAddressFromPublicKey(pub)
+	return address, err
+}
+
+// CheckAddressFormat 验证钱包地址是否是合法的格式。
+// 如果成功，返回true和对应的版本号；如果失败，返回false和默认的版本号0
+func (xcc SchnorrCryptoClient) CheckAddressFormat(address string) (bool, uint8) {
+	isValid, nVersion := account.CheckAddressFormat(address)
+	return isValid, nVersion
+}
+
+// VerifyAddressUsingPublicKey 验证钱包地址是否和指定的公钥match。
+// 如果成功，返回true和对应的版本号；如果失败，返回false和默认的版本号0
+func (xcc SchnorrCryptoClient) VerifyAddressUsingPublicKey(address string, pub *ecdsa.PublicKey) (bool, uint8) {
+	isValid, nVersion := account.VerifyAddressUsingPublicKey(address, pub)
+	return isValid, nVersion
+}
+
 // --- 	schnorr 环签名算法相关 start ---
 
 // SignSchnorrRing schnorr环签名算法 生成统一签名

--- a/core/crypto/client/xchain/xchain_crypto_client.go
+++ b/core/crypto/client/xchain/xchain_crypto_client.go
@@ -123,6 +123,26 @@ func (xcc XchainCryptoClient) GetEcdsaPrivateKeyFromFile(filename string) (*ecds
 	return ecdsaPrivateKey, err
 }
 
+// GetAddressFromPublicKey 通过公钥来计算地址
+func (xcc XchainCryptoClient) GetAddressFromPublicKey(pub *ecdsa.PublicKey) (string, error) {
+	address, err := account.GetAddressFromPublicKey(pub)
+	return address, err
+}
+
+// CheckAddressFormat 验证钱包地址是否是合法的格式。
+// 如果成功，返回true和对应的版本号；如果失败，返回false和默认的版本号0
+func (xcc XchainCryptoClient) CheckAddressFormat(address string) (bool, uint8) {
+	isValid, nVersion := account.CheckAddressFormat(address)
+	return isValid, nVersion
+}
+
+// VerifyAddressUsingPublicKey 验证钱包地址是否和指定的公钥match。
+// 如果成功，返回true和对应的版本号；如果失败，返回false和默认的版本号0
+func (xcc XchainCryptoClient) VerifyAddressUsingPublicKey(address string, pub *ecdsa.PublicKey) (bool, uint8) {
+	isValid, nVersion := account.VerifyAddressUsingPublicKey(address, pub)
+	return isValid, nVersion
+}
+
 // GetEcdsaPublicKeyFromFile 从导出的公钥文件读取公钥
 func (xcc XchainCryptoClient) GetEcdsaPublicKeyFromFile(filename string) (*ecdsa.PublicKey, error) {
 	ecdsaPublicKey, err := account.GetEcdsaPublicKeyFromFile(filename)


### PR DESCRIPTION
## Description

Now the gm crypto client is using SHA256 hasher in address generating, we could change it to SM3 to make gm crypto client more secure. This also make sure the gm crypto client of xchain and go sdk are match.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
