### PR TITLE
bugfix： group chain can not work 

### DIFF
--- a/core/core/xchainmg_net.go
+++ b/core/core/xchainmg_net.go
@@ -61,7 +61,7 @@ func (xm *XChainMG) StartLoop() {
 		select {
 		case msg := <-xm.msgChan:
 			// handle received msg
-			xm.Log.Info("XchainMG get msg", "logid", msg.GetHeader().GetLogid(), "msgType", msg.GetHeader().GetType(), "checksum", msg.GetHeader().GetDataCheckSum())
+			xm.Log.Info("XchainMG get msg", "logid", msg.GetHeader().GetLogid(), "msgType", msg.GetHeader().GetType(), "checksum", msg.GetHeader().GetDataCheckSum(), "from", msg.GetHeader().GetFrom())
 			go xm.handleReceivedMsg(msg)
 		}
 	}

--- a/core/p2p/p2pv2/server.go
+++ b/core/p2p/p2pv2/server.go
@@ -271,16 +271,9 @@ func (p *P2PServerV2) GetPeerIDAndUrls() map[string]string {
 	id2Url := map[string]string{}
 	peers := p.node.ListPeers()
 	for _, v := range peers {
-		if s, err := p.node.strPool.FindStream(v); err == nil {
-			if s.gp == "" {
-				s.getRPCPort()
-			}
-			peerID := string(v.Pretty())
-			ipStr := s.addr.String() + "/p2p/" + peerID
-			id2Url[peerID] = ipStr
-		}
+		peerID := string(v.Pretty())
+		id2Url[peerID] = peerID
 	}
-
 	return id2Url
 }
 

--- a/core/utxo/group_chain.go
+++ b/core/utxo/group_chain.go
@@ -11,19 +11,19 @@ func (uv *UtxoVM) QueryChainInList() map[string]bool {
 	return uv.getChainInList()
 }
 
-func (uv *UtxoVM) QueryIPsInList(bcname string) map[string]bool {
-	return uv.getIPsInList(bcname)
+func (uv *UtxoVM) QueryPeerIDsInList(bcname string) map[string]bool {
+	return uv.getPeerIDsInList(bcname)
 }
 
-func (uv *UtxoVM) getIPsInList(bcname string) map[string]bool {
-	ipMap := map[string]bool{}
+func (uv *UtxoVM) getPeerIDsInList(bcname string) map[string]bool {
+	peerIDMap := map[string]bool{}
 	args := map[string][]byte{
 		"bcname": []byte(bcname),
 	}
 
 	groupChainContract := uv.GetGroupChainContract()
 	if groupChainContract == nil {
-		return ipMap
+		return peerIDMap
 	}
 	moduleName := groupChainContract.ModuleName
 	contractName := groupChainContract.ContractName
@@ -32,19 +32,26 @@ func (uv *UtxoVM) getIPsInList(bcname string) map[string]bool {
 	uv.xlog.Trace("check IP list of group", "moduleName:", moduleName, "contractName:", contractName, "methodName:", methodName, "bcname", bcname)
 
 	if moduleName == "" && contractName == "" && methodName == "" {
-		return ipMap
+		return peerIDMap
 	}
 
 	status, target, err := uv.queryGroupChain(moduleName, contractName, methodName, args)
 	if status >= 400 || err != nil || string(target) == "" {
-		return ipMap
+		return peerIDMap
 	}
 	res := strings.Split(string(target), "\x01")
 	for _, v := range res {
-		ipMap[v] = true
+		arr := strings.Split(v, "/")
+		if len(arr) <= 0 {
+			continue
+		}
+		peerID := arr[len(arr)-1]
+		if peerID == "" {
+			continue
+		}
+		peerIDMap[peerID] = true
 	}
-
-	return ipMap
+	return peerIDMap
 }
 
 func (uv *UtxoVM) getChainInList() map[string]bool {


### PR DESCRIPTION
## Description

What is the purpose of the change?

Group chain can not work because the port of cli is the random port. So it's not safe to check whether the netURL equal while receive new message. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Use PeerID rather than netURL to check  whether the node in group while send and receive message.
