### PR TITLE
xchain-cli support endorser bug fixed

### DIFF
--- a/core/cmd/cli/comm_trans.go
+++ b/core/cmd/cli/comm_trans.go
@@ -1056,6 +1056,19 @@ func (c *CommTrans) GenComplianceCheckTx(utxoOutput *pb.UtxoOutput) (*pb.Transac
 	if err != nil {
 		return nil, err
 	}
+	fromAddr, err := readAddress(c.Keys)
+	if err != nil {
+		return nil, err
+	}
+
+	var authRequire string
+	if c.From != "" {
+		authRequire = c.From + "/" + fromAddr
+	} else {
+		authRequire = fromAddr
+	}
+	tx.AuthRequire = append(tx.AuthRequire, authRequire)
+
 	signTx, err := txhash.ProcessSignTx(cryptoClient, tx, []byte(fromScrkey))
 	if err != nil {
 		return nil, err
@@ -1070,6 +1083,7 @@ func (c *CommTrans) GenComplianceCheckTx(utxoOutput *pb.UtxoOutput) (*pb.Transac
 	signatureInfos = append(signatureInfos, signatureInfo)
 
 	tx.InitiatorSigns = signatureInfos
+	tx.AuthRequireSigns = signatureInfos
 
 	// make txid
 	tx.Txid, _ = txhash.MakeTransactionID(tx)


### PR DESCRIPTION
## Description

What is the purpose of the change?
To fix bug.  

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution
The tx of paying endorser fee  add AuthRequires and AuthRequireSigns
like this:
tx.AuthRequire = append(tx.AuthRequire, authRequire)
tx.AuthRequireSigns = signatureInfos

## How Has This Been Tested?
use cli cmd
./xchain-cli native deploy --account XC1111111111111111@xuper -a '{"creator":"XC1111111111111111@xuper"}' --runtime go counter --cname golangcounter --fee 12970389 --cliconfpath conf/cli.yaml
./xchain-cli native invoke --method Increase -a '{"key":"test"}' golangcounter --fee 54 --cliconfpath conf/cli.yaml
./xchain-cli native upgrade --cname golangcountera --account XCXC1111111111111111@xuper counternew --cliconfpath conf/cli.yaml --fee 12970359
