### PR TITLE
Fix contract concurrent bug

### DIFF
--- a/core/utxo/spin_lock.go
+++ b/core/utxo/spin_lock.go
@@ -1,10 +1,12 @@
 package utxo
 
 import (
-	"github.com/xuperchain/xuperchain/core/pb"
 	"sort"
 	"strconv"
 	"sync"
+
+	"github.com/xuperchain/xuperchain/core/pb"
+	"github.com/xuperchain/xuperchain/core/xmodel"
 )
 
 const (
@@ -75,6 +77,9 @@ func (sp *SpinLock) ExtractLockKeys(tx *pb.Transaction) []*LockKey {
 		readKeys[k] = true
 	}
 	for _, output := range tx.TxOutputsExt {
+		if string(output.Bucket) == xmodel.TransientBucket {
+			continue
+		}
 		k := string(output.Bucket) + "/" + string(output.Key)
 		delete(readKeys, k)
 		writeKeys[k] = true

--- a/core/utxo/spin_lock.go
+++ b/core/utxo/spin_lock.go
@@ -73,14 +73,14 @@ func (sp *SpinLock) ExtractLockKeys(tx *pb.Transaction) []*LockKey {
 	readKeys := map[string]bool{}
 	writeKeys := map[string]bool{}
 	for _, input := range tx.TxInputsExt {
-		k := string(input.Bucket) + "/" + string(input.Key)
+		k := input.Bucket + "/" + string(input.Key)
 		readKeys[k] = true
 	}
 	for _, output := range tx.TxOutputsExt {
-		if string(output.Bucket) == xmodel.TransientBucket {
+		if output.Bucket == xmodel.TransientBucket {
 			continue
 		}
-		k := string(output.Bucket) + "/" + string(output.Key)
+		k := output.Bucket + "/" + string(output.Key)
 		delete(readKeys, k)
 		writeKeys[k] = true
 	}


### PR DESCRIPTION
## Description

Fix the concurrency bug when the contract method contains event trigger. When locking the key in the output, if the bucket contains ¥transient, skip it.