### PR TITLE
log level change to debug in getValidates

### DIFF
--- a/core/consensus/common/chainedbft/smr/smr.go
+++ b/core/consensus/common/chainedbft/smr/smr.go
@@ -492,7 +492,7 @@ func (s *Smr) voteProposal(propsQC *pb.QuorumCert, voteTo, logid string) error {
 }
 
 func (s *Smr) getValidates(viewNumer int64) []*cons_base.CandidateInfo {
-	s.slog.Error("getValidates", "effectiveDelay", s.effectiveDelay, "s.vscView", s.vscView)
+	s.slog.Debug("getValidates", "effectiveDelay", s.effectiveDelay, "s.vscView", s.vscView)
 	// 根据不同共识的生效延时，判断当前view是否需要使用哪个验证集合，viewNumer为新视图，vscView为上次变更候选人视图
 	if s.effectiveDelay > 0 && viewNumer == s.vscView+s.effectiveDelay {
 		for _, v := range s.preValidates {


### PR DESCRIPTION
## Description

nodes num: 3
consensus:xpoa
version:master

when smr.addViewMsg is invoked , log level in getValidates allways be error

Fixes # (issue)
change log level from error to debug

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution



## How Has This Been Tested?

setup xchain with 3 nodes and xpoa 
