### PR TITLE
cli: only fetch block header

### DIFF
--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -885,7 +885,7 @@ func (xc *XChainCore) GetBlockChainStatus(in *pb.BCStatus, viewOption pb.ViewOpt
 		utxoMeta := xc.Utxovm.GetMeta()
 		out.UtxoMeta = utxoMeta
 	}
-	ib, err := xc.Ledger.QueryBlock(meta.TipBlockid)
+	ib, err := xc.Ledger.QueryBlockHeader(meta.TipBlockid)
 	if err != nil {
 		out.Header.Error = HandlerLedgerError(err)
 		return out


### PR DESCRIPTION
## Description

Avoid exceeding the maximum message limit caused by large blocks in the status command.
