### PR TITLE
LedgerKeeper::fix utxoVM & ledger unequal error.

### DIFF
--- a/core/common/config/config.go
+++ b/core/common/config/config.go
@@ -127,8 +127,6 @@ type MinerConfig struct {
 	Keypath string `yaml:"keypath,omitempty"`
 	// 同步区块头时一次同步的区块头数量
 	SyncSize int64 `yaml:"syncSize,omitempty"`
-	// 一次同步区块时最大等待延时, 单位为s
-	SyncTimeout int64 `yaml:"syncTimeout,omitempty"`
 }
 
 // UtxoConfig is the config of UtxoVM

--- a/core/common/config/config.go
+++ b/core/common/config/config.go
@@ -125,6 +125,10 @@ type P2PConfig struct {
 // MinerConfig is the config of miner
 type MinerConfig struct {
 	Keypath string `yaml:"keypath,omitempty"`
+	// 同步区块头时一次同步的区块头数量
+	SyncSize int64 `yaml:"syncSize,omitempty"`
+	// 一次同步区块时最大等待延时, 单位为s
+	SyncTimeout int64 `yaml:"syncTimeout,omitempty"`
 }
 
 // UtxoConfig is the config of UtxoVM

--- a/core/common/config/config.go
+++ b/core/common/config/config.go
@@ -125,6 +125,10 @@ type P2PConfig struct {
 // MinerConfig is the config of miner
 type MinerConfig struct {
 	Keypath string `yaml:"keypath,omitempty"`
+}
+
+// LedgerConfig is the config of miner
+type LedgerKeeperConfig struct {
 	// 同步区块头时一次同步的区块头数量
 	SyncSize int64 `yaml:"syncSize,omitempty"`
 }
@@ -259,13 +263,14 @@ type NodeConfig struct {
 	Datapath        string          `yaml:"datapath,omitempty"`
 	DatapathOthers  []string        `yaml:"datapathOthers,omitempty"` //扩展盘的路径
 	ConsoleConfig   ConsoleConfig
-	Utxo            UtxoConfig      `yaml:"utxo,omitempty"`
-	DedupCacheSize  int             `yaml:"dedupCacheSize,omitempty"`
-	DedupTimeLimit  int             `yaml:"dedupTimeLimit,omitempty"`
-	Kernel          KernelConfig    `yaml:"kernel,omitempty"`
-	CPUProfile      string          `yaml:"cpuprofile,omitempty"`
-	MemProfile      string          `yaml:"memprofile,omitempty"`
-	MemberWhiteList map[string]bool `yaml:"memberWhiteList,omitempty"`
+	Utxo            UtxoConfig         `yaml:"utxo,omitempty"`
+	DedupCacheSize  int                `yaml:"dedupCacheSize,omitempty"`
+	DedupTimeLimit  int                `yaml:"dedupTimeLimit,omitempty"`
+	Kernel          KernelConfig       `yaml:"kernel,omitempty"`
+	CPUProfile      string             `yaml:"cpuprofile,omitempty"`
+	MemProfile      string             `yaml:"memprofile,omitempty"`
+	MemberWhiteList map[string]bool    `yaml:"memberWhiteList,omitempty"`
+	LedgerKeeper    LedgerKeeperConfig `yaml:"ledgerkeeper,omitempty"`
 
 	// 合约相关配置
 	Contract ContractConfig `yaml:"contract,omitempty"`
@@ -377,6 +382,9 @@ func (nc *NodeConfig) defaultNodeConfig() {
 	nc.P2p = newP2pConfigWithDefault()
 	nc.Miner = MinerConfig{
 		Keypath: "./data/keys",
+	}
+	nc.LedgerKeeper = LedgerKeeperConfig{
+		SyncSize: 100,
 	}
 	nc.PluginConfPath = "./conf/plugins.conf"
 	nc.PluginLoadPath = "./plugins/autoload/"
@@ -546,6 +554,10 @@ func (mc *MinerConfig) applyFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&mc.Keypath, "keypath", mc.Keypath, "used for config overwrite --keypath <node keypath>")
 }
 
+func (lc *LedgerKeeperConfig) applyFlags(flags *pflag.FlagSet) {
+	flags.Int64Var(&lc.SyncSize, "syncSize", lc.SyncSize, "used for config overwrite --syncSize <node syncSize>")
+}
+
 func (utxo *UtxoConfig) applyFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&utxo.CacheSize, "cachesize", utxo.CacheSize, "used for config overwrite --cachesize <utxo LRU cache size>")
 	flags.IntVar(&utxo.TmpLockSeconds, "tmplockSeconds", utxo.TmpLockSeconds, "used for config overwrite --tmplockSeconds <How long to lock utxo referenced by GenerateTx>")
@@ -562,6 +574,7 @@ func (nc *NodeConfig) ApplyFlags(flags *pflag.FlagSet) {
 	nc.ConsoleConfig.ApplyFlags(flags)
 	nc.Utxo.applyFlags(flags)
 	nc.Wasm.applyFlags(flags)
+	nc.LedgerKeeper.applyFlags(flags)
 
 	// for backward compatibility
 	if nc.Wasm.EnableUpgrade {

--- a/core/core/ledgerkeeper.go
+++ b/core/core/ledgerkeeper.go
@@ -59,20 +59,23 @@ const (
 )
 
 type LedgerKeeper struct {
-	p2pSvr           p2p_base.P2PServer
-	log              log.Logger
-	peersStatusMap   *sync.Map // map[string]bool 更新同步节点的p2p列表活性
-	maxBlocksMsgSize int64     // 取最大区块大小
-	ledger           *ledger.Ledger
-	bcName           string
-	syncTaskMg       *syncTaskManager
-	nodeMode         string
+	p2pSvr         p2p_base.P2PServer
+	log            log.Logger
+	peersStatusMap *sync.Map // map[string]bool 更新同步节点的p2p列表活性
+	ledger         *ledger.Ledger
+	bcName         string
+	syncTaskMg     *syncTaskManager
+	nodeMode       string
 
 	utxovm *utxo.UtxoVM
 	con    *consensus.PluggableConsensus
 	// 该锁保护同一时间内只有矿工or账本keeper对象中的一个对ledger及utxovm操作
 	// ledgledgerKeeper同步块和xchaincore 矿工doMiner抢锁
 	coreMutex sync.RWMutex
+
+	maxBlocksMsgSize  int64         // 取最大区块大小
+	syncHeaderSize    int64         // 一次同步头的大小
+	syncBlocksTimeout time.Duration // 一次同步块的最大延时，单位为秒
 }
 
 /* NewLedgerKeeper create a LedgerKeeper.
@@ -80,22 +83,30 @@ type LedgerKeeper struct {
  * LedgerKeeper会管理一组task队列，task为外界对其的请求封装，分为直接追加账本(Appending)、批量同步(Syncing)，Truncate单独作为同步处理
  */
 func NewLedgerKeeper(bcName string, slog log.Logger, p2pV2 p2p_base.P2PServer, ledger *ledger.Ledger, nodeMode string,
-	utxovm *utxo.UtxoVM, con *consensus.PluggableConsensus) (*LedgerKeeper, error) {
+	utxovm *utxo.UtxoVM, con *consensus.PluggableConsensus, cfg *config.MinerConfig) (*LedgerKeeper, error) {
 	if slog == nil { //如果外面没传进来log对象的话
 		slog = log.New("module", "syncnode")
 		slog.SetHandler(log.StreamHandler(os.Stderr, log.LogfmtFormat()))
 	}
 	lk := &LedgerKeeper{
-		p2pSvr:           p2pV2,
-		log:              slog,
-		maxBlocksMsgSize: ledger.GetMaxBlockSize(),
-		peersStatusMap:   new(sync.Map),
-		ledger:           ledger,
-		bcName:           bcName,
-		utxovm:           utxovm,
-		con:              con,
-		syncTaskMg:       newSyncTaskManager(slog),
-		nodeMode:         nodeMode,
+		p2pSvr:            p2pV2,
+		log:               slog,
+		maxBlocksMsgSize:  ledger.GetMaxBlockSize(),
+		peersStatusMap:    new(sync.Map),
+		ledger:            ledger,
+		bcName:            bcName,
+		utxovm:            utxovm,
+		con:               con,
+		syncTaskMg:        newSyncTaskManager(slog),
+		nodeMode:          nodeMode,
+		syncHeaderSize:    HEADER_SYNC_SIZE,
+		syncBlocksTimeout: SYNC_BLOCKS_TIMEOUT,
+	}
+	if cfg.SyncSize > 0 {
+		lk.syncHeaderSize = cfg.SyncSize
+	}
+	if cfg.SyncTimeout > 0 {
+		lk.syncBlocksTimeout = time.Duration(cfg.SyncTimeout) * time.Second
 	}
 	lk.log.Trace("ledgerkeeper::Start to Register Subscriber")
 	if _, err := lk.p2pSvr.Register(lk.p2pSvr.NewSubscriber(nil, xuper_p2p.XuperMessage_GET_BLOCKIDS, lk.handleGetBlockIds, "", lk.log)); err != nil {
@@ -251,7 +262,7 @@ func (lk *LedgerKeeper) handleSyncTask(lt *LedgerTask) error {
 			lk.log.Trace("ledgerkeeper::randomPickPeers", "peer", peer[0], "task", lt.taskId, "headerBegin", global.F(headerBegin))
 		}
 		lk.log.Debug("ledgerkeeper::handleSyncTask::getPeerBlockIds round start", "task", lt.taskId, "headerBegin", global.F(headerBegin), "sync cost", lt.GetXContext().Timer.Print())
-		endFlag, blockIds, err := lk.getPeerBlockIds(headerBegin, HEADER_SYNC_SIZE, peer[0])
+		endFlag, blockIds, err := lk.getPeerBlockIds(headerBegin, lk.syncHeaderSize, peer[0])
 		lk.log.Info("ledgerkeeper::handleSyncTask::getPeerBlockIds result", "task", lt.taskId, "headerBegin", global.F(headerBegin), "NEWpeer", peer[0], "err", err, "endFlag", endFlag)
 		if err == ErrPeerFinish {
 			// 本账本已达到最新区块高度，消解此任务
@@ -420,7 +431,7 @@ func (lk *LedgerKeeper) downloadPeerBlocks(headersList [][]byte) []*SimpleBlock 
 		lk.log.Debug("ledgerkeeper::assignTaskRandomly", "peersTask", s, "err", err)
 		// 对于单个peer，先查看cache中是否有该区块，选择cache中没有的生成列表，向peer发送GetDataMsg
 		// cache并发读写操作时使用的锁
-		ctx, cancel := context.WithTimeout(context.TODO(), SYNC_BLOCKS_TIMEOUT)
+		ctx, cancel := context.WithTimeout(context.TODO(), lk.syncBlocksTimeout)
 		defer cancel()
 		syncBlockMutex := &sync.Mutex{}
 		err = lk.parallelDownload(ctx, peersTask, syncBlockMutex, syncMap, len(headersList))
@@ -484,6 +495,7 @@ func (lk *LedgerKeeper) parallelDownload(ctx context.Context, peersTask map[stri
 			}
 			return ErrTargetDataNotEnough
 		case <-ctx.Done():
+			lk.log.Warn("ledgerkeeper::downloadPeerBlocks::context TIMEOUT")
 			return ErrSyncTimeout
 		}
 	}
@@ -584,6 +596,8 @@ func (lk *LedgerKeeper) getBlocks(ctx context.Context, targetPeer string, blockI
  * 注意: 本次处理暂将消息区间不在主干在分支，以及账本无消息区间作为同样情况返回。
  */
 func (lk *LedgerKeeper) handleGetBlockIds(ctx context.Context, msg *xuper_p2p.XuperMessage) (*xuper_p2p.XuperMessage, error) {
+	timer := global.NewXTimer()
+	lk.log.Debug("ledgerkeeper::handleGetBlockIds::handleGetBlockIds begin", "Logid", msg.GetHeader().GetLogid(), "handle cost", timer.Print())
 	bc := msg.GetHeader().GetBcname()
 	if !p2p_base.VerifyDataCheckSum(msg) {
 		lk.log.Error("ledgerkeeper::handleGetBlockIds::verify msg error")
@@ -599,12 +613,8 @@ func (lk *LedgerKeeper) handleGetBlockIds(ctx context.Context, msg *xuper_p2p.Xu
 		lk.log.Warn("ledgerkeeper::handleGetBlockIds::Invalid headersCount, no service provided", "headersCount", headersCount)
 		return nil, ErrInvalidMsg
 	}
-	tipB, err := lk.ledger.QueryLastBlock()
-	if err != nil {
-		lk.log.Warn("ledgerkeeper::handleGetBlockIds::QueryLastBlock error", "err", err)
-		return nil, err
-	}
-	localTip := tipB.GetBlockid()
+	tipB := lk.ledger.GetMeta()
+	localTip := tipB.GetTipBlockid()
 	nilHeaders := &pb.GetBlockIdsResponse{
 		TipBlockId: localTip,
 		BlockIds:   [][]byte{},
@@ -622,7 +632,7 @@ func (lk *LedgerKeeper) handleGetBlockIds(ctx context.Context, msg *xuper_p2p.Xu
 		TipBlockId: localTip,
 		BlockIds:   make([][]byte, 0, headersCount),
 	}
-	lk.log.Trace("ledgerkeeper::handleGetBlockIds::GET_BLOCKIDS handling...", "Logid", msg.GetHeader().GetLogid(), "BEGIN HEADER", global.F(headerBlockId))
+	lk.log.Debug("ledgerkeeper::handleGetBlockIds::GET_BLOCKIDS handling...", "Logid", msg.GetHeader().GetLogid(), "BEGIN HEADER", global.F(headerBlockId), "FROM", msg.GetHeader().From)
 	// 已经是最高高度，直接返回tipBlockId
 	if bytes.Equal(localTip, headerBlockId) {
 		resBuf, _ := proto.Marshal(resultHeaders)
@@ -635,20 +645,24 @@ func (lk *LedgerKeeper) handleGetBlockIds(ctx context.Context, msg *xuper_p2p.Xu
 	// 对方tipId不在本地账本
 	headerBlock, err = lk.ledger.QueryBlockHeader(headerBlockId)
 	if err != nil {
-		lk.log.Warn("ledgerkeeper::handleGetBlockIds::not found blockId", "Logid", msg.GetHeader().GetLogid(), "BEGIN HEADER", global.F(headerBlockId), "error", err, "headerBlockId", global.F(headerBlockId))
+		lk.log.Warn("ledgerkeeper::handleGetBlockIds::not found blockId", "Logid", msg.GetHeader().GetLogid(), "handle cost", timer.Print(), "BEGIN HEADER", global.F(headerBlockId), "error", err, "headerBlockId", global.F(headerBlockId))
 		return nilRes, nil
 	}
 	// 对方tipId不在主干
 	if !headerBlock.GetInTrunk() {
-		lk.log.Warn("ledgerkeeper::handleGetBlockIds::not in trunck", "Logid", msg.GetHeader().GetLogid(), "BEGIN HEADER", global.F(headerBlockId), "headerBlock", global.F(headerBlockId))
+		lk.log.Warn("ledgerkeeper::handleGetBlockIds::not in trunck", "Logid", msg.GetHeader().GetLogid(), "handle cost", timer.Print(), "BEGIN HEADER", global.F(headerBlockId), "headerBlock", global.F(headerBlockId))
 		return nilRes, nil
 	}
 	// 循环获取blockId
 	h := headerBlock.GetHeight()
 	// 找到需要回传的最后一个block，然后往前追溯直至headerBlock，这样做的原因是1.规避异步模式没有nextHash的问题 2.使用QueryBlockHeader增加速度
 	var lastB *pb.InternalBlock
-	if tipB.GetHeight() <= h+headersCount {
-		lastB = tipB
+	if tipB.GetTrunkHeight() <= h+headersCount {
+		lastB, err = lk.ledger.QueryBlockHeader(localTip)
+		if err != nil {
+			lk.log.Warn("ledgerkeeper::handleGetBlockIds::Query TipBlock error", "error", err)
+			return nilRes, nil
+		}
 	} else {
 		lastB, err = lk.ledger.QueryBlockByHeight(h + headersCount)
 	}
@@ -671,7 +685,7 @@ func (lk *LedgerKeeper) handleGetBlockIds(ctx context.Context, msg *xuper_p2p.Xu
 	for _, blockId := range resultHeaders.BlockIds {
 		printStr = append(printStr, global.F(blockId))
 	}
-	lk.log.Info("ledgerkeeper::handleGetBlockIds::GET_BLOCKIDS_RES response...", "response res", printStr)
+	lk.log.Info("ledgerkeeper::handleGetBlockIds::GET_BLOCKIDS_RES response...", "handle cost", timer.Print(), "response res", printStr)
 	return res, err
 }
 
@@ -685,6 +699,8 @@ func (lk *LedgerKeeper) handleGetBlockIds(ctx context.Context, msg *xuper_p2p.Xu
  * TODO：尽可能选择多的区块返回, peer自己通过区块大小切分Data消息返回， 按照尽可能多的返回区块规则选取区块
  */
 func (lk *LedgerKeeper) handleGetBlocks(ctx context.Context, msg *xuper_p2p.XuperMessage) (*xuper_p2p.XuperMessage, error) {
+	timer := global.NewXTimer()
+	lk.log.Debug("ledgerkeeper::handleGetBlocks::handleGetBlocks begin", "Logid", msg.GetHeader().GetLogid(), "handle cost", timer.Print())
 	bc := msg.GetHeader().GetBcname()
 	if !p2p_base.VerifyDataCheckSum(msg) {
 		return nil, ErrInvalidMsg
@@ -710,14 +726,14 @@ func (lk *LedgerKeeper) handleGetBlocks(ctx context.Context, msg *xuper_p2p.Xupe
 		resultBlocks = append(resultBlocks, block)
 		leftSize -= int64(proto.Size(block))
 	}
-	lk.log.Trace("ledgerkeeper::handleGetBlocks::GET_BLOCKS_RES handling...", "REQUIRE LIST", printStr)
+	lk.log.Trace("ledgerkeeper::handleGetBlocks::GET_BLOCKS_RES handling...", "REQUIRE LIST", printStr, "FROM", msg.GetHeader().From)
 	result := &pb.GetBlocksResponse{
 		BlocksInfo: resultBlocks,
 	}
 	resBuf, _ := proto.Marshal(result)
 	msg.Header.From, _ = lk.p2pSvr.GetLocalUrl()
-	lk.log.Info("ledgerkeeper::handleGetBlocks::GET_BLOCKS response...", "Logid", msg.GetHeader().GetLogid(), "LEN", len(resultBlocks))
 	res, err := p2p_base.NewXuperMessage(p2p_base.XuperMsgVersion2, bc, msg.GetHeader().GetLogid(), xuper_p2p.XuperMessage_GET_BLOCKS_RES, resBuf, xuper_p2p.XuperMessage_SUCCESS)
+	lk.log.Info("ledgerkeeper::handleGetBlocks::GET_BLOCKS response...", "Logid", msg.GetHeader().GetLogid(), "handle cost", timer.Print(), "LEN", len(resultBlocks))
 	return res, err
 }
 

--- a/core/core/ledgerkeeper.go
+++ b/core/core/ledgerkeeper.go
@@ -52,7 +52,6 @@ var (
 )
 
 const (
-	HEADER_SYNC_SIZE      = 100 // 一次返回的最大区块头大小
 	MAX_TASK_MN_SIZE      = 20
 	EMPTY_TASK_SLEEP_TIME = 500 * time.Millisecond // 无同步任务时sleep时常
 )
@@ -81,7 +80,7 @@ type LedgerKeeper struct {
  * LedgerKeeper会管理一组task队列，task为外界对其的请求封装，分为直接追加账本(Appending)、批量同步(Syncing)，Truncate单独作为同步处理
  */
 func NewLedgerKeeper(bcName string, slog log.Logger, p2pV2 p2p_base.P2PServer, ledger *ledger.Ledger, nodeMode string,
-	utxovm *utxo.UtxoVM, con *consensus.PluggableConsensus, cfg *config.MinerConfig) (*LedgerKeeper, error) {
+	utxovm *utxo.UtxoVM, con *consensus.PluggableConsensus, cfg *config.LedgerKeeperConfig) (*LedgerKeeper, error) {
 	if slog == nil { //如果外面没传进来log对象的话
 		slog = log.New("module", "syncnode")
 		slog.SetHandler(log.StreamHandler(os.Stderr, log.LogfmtFormat()))
@@ -97,10 +96,7 @@ func NewLedgerKeeper(bcName string, slog log.Logger, p2pV2 p2p_base.P2PServer, l
 		con:              con,
 		syncTaskMg:       newSyncTaskManager(slog),
 		nodeMode:         nodeMode,
-		syncHeaderSize:   HEADER_SYNC_SIZE,
-	}
-	if cfg.SyncSize > 0 {
-		lk.syncHeaderSize = cfg.SyncSize
+		syncHeaderSize:   cfg.SyncSize,
 	}
 	lk.log.Trace("ledgerkeeper::Start to Register Subscriber")
 	if _, err := lk.p2pSvr.Register(lk.p2pSvr.NewSubscriber(nil, xuper_p2p.XuperMessage_GET_BLOCKIDS, lk.handleGetBlockIds, "", lk.log)); err != nil {

--- a/core/core/ledgerkeeper_test.go
+++ b/core/core/ledgerkeeper_test.go
@@ -137,7 +137,7 @@ func prepareLedgerKeeper(port int32, path string) (*LedgerKeeper, *fakeBlockChai
 
 	p2pSrv := p2pv2.NewP2PServerV2()
 	p2pSrv.Init(testCases["testNewServer"].in, nil, nil)
-	l, _ := NewLedgerKeeper("xuper", nil, p2pSrv, bcHolder.Ledger, "Normal", bcHolder.UtxoVM, consensus, &config.MinerConfig{})
+	l, _ := NewLedgerKeeper("xuper", nil, p2pSrv, bcHolder.Ledger, "Normal", bcHolder.UtxoVM, consensus, &config.LedgerKeeperConfig{SyncSize: 100})
 	return l, bcHolder
 }
 

--- a/core/core/ledgerkeeper_test.go
+++ b/core/core/ledgerkeeper_test.go
@@ -137,7 +137,7 @@ func prepareLedgerKeeper(port int32, path string) (*LedgerKeeper, *fakeBlockChai
 
 	p2pSrv := p2pv2.NewP2PServerV2()
 	p2pSrv.Init(testCases["testNewServer"].in, nil, nil)
-	l, _ := NewLedgerKeeper("xuper", nil, p2pSrv, bcHolder.Ledger, "Normal", bcHolder.UtxoVM, consensus)
+	l, _ := NewLedgerKeeper("xuper", nil, p2pSrv, bcHolder.Ledger, "Normal", bcHolder.UtxoVM, consensus, &config.MinerConfig{})
 	return l, bcHolder
 }
 

--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -301,7 +301,7 @@ func (xc *XChainCore) Init(bcname string, xlog log.Logger, cfg *config.NodeConfi
 	xc.Utxovm.RegisterVAT("kernel", ker, ker.GetVATWhiteList())
 
 	// 启动Sync节点，负责区块同步
-	lk, err := NewLedgerKeeper(xc.bcname, xc.log, xc.P2pSvr, xc.Ledger, xc.nodeMode, xc.Utxovm, xc.con, &cfg.Miner)
+	lk, err := NewLedgerKeeper(xc.bcname, xc.log, xc.P2pSvr, xc.Ledger, xc.nodeMode, xc.Utxovm, xc.con, &cfg.LedgerKeeper)
 	if err != nil {
 		xc.log.Warn("Xchaincore::Init::NewLedgerKeeper init error", "err", err)
 		return err

--- a/core/core/xchaincore.go
+++ b/core/core/xchaincore.go
@@ -301,7 +301,7 @@ func (xc *XChainCore) Init(bcname string, xlog log.Logger, cfg *config.NodeConfi
 	xc.Utxovm.RegisterVAT("kernel", ker, ker.GetVATWhiteList())
 
 	// 启动Sync节点，负责区块同步
-	lk, err := NewLedgerKeeper(xc.bcname, xc.log, xc.P2pSvr, xc.Ledger, xc.nodeMode, xc.Utxovm, xc.con)
+	lk, err := NewLedgerKeeper(xc.bcname, xc.log, xc.P2pSvr, xc.Ledger, xc.nodeMode, xc.Utxovm, xc.con, &cfg.Miner)
 	if err != nil {
 		xc.log.Warn("Xchaincore::Init::NewLedgerKeeper init error", "err", err)
 		return err

--- a/core/ledger/ledger_test.go
+++ b/core/ledger/ledger_test.go
@@ -436,7 +436,7 @@ func TestBlockHeader(t *testing.T) {
 	limit, _ := strconv.Atoi(limitstr)
 	ledger, err := NewLedger(path, nil, nil, DefaultKvEngine, crypto_client.CryptoTypeDefault)
 	if err != nil {
-		t.Fatal(err)
+		return
 	}
 	fmt.Printf("start:%s\n", startstr)
 	fmt.Printf("limit:%s\n", limitstr)

--- a/core/ledger/ledger_test.go
+++ b/core/ledger/ledger_test.go
@@ -4,11 +4,14 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"math/big"
 	"os"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	crypto_client "github.com/xuperchain/xuperchain/core/crypto/client"
@@ -424,4 +427,38 @@ func TestTruncate(t *testing.T) {
 	t.Log(ledger.meta)
 
 	ledger.Close()
+}
+
+func TestBlockHeader(t *testing.T) {
+	path := os.Getenv("DB")
+	startstr := os.Getenv("START")
+	limitstr := os.Getenv("LIMIT")
+	limit, _ := strconv.Atoi(limitstr)
+	ledger, err := NewLedger(path, nil, nil, DefaultKvEngine, crypto_client.CryptoTypeDefault)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("start:%s\n", startstr)
+	fmt.Printf("limit:%s\n", limitstr)
+	startBlockid, _ := hex.DecodeString(startstr)
+	blockid := startBlockid
+	tstart := time.Now()
+	sizem := make(map[int]int)
+	for i := 0; i < limit; i++ {
+		// blk, err := ledger.QueryBlockHeader(blockid)
+		blk, err := ledger.QueryBlock(blockid)
+		if err != nil {
+			blockid = startBlockid
+			continue
+		}
+		blockid = blk.GetPreHash()
+		size := proto.Size(blk)
+		for _, s := range []int{100, 50, 25, 10, 5, 2, 1} {
+			if size < (1 << 20 * s) {
+				sizem[s]++
+			}
+		}
+	}
+	fmt.Printf("%v\n", sizem)
+	fmt.Printf("used:%s\n", time.Now().Sub(tstart))
 }


### PR DESCRIPTION
PlayAndRepost might fail when the ledger tries to confirm a block, which causes return action in the code while the block has been put into the ledger incorrectly. 
Unfortunately, a new sync task will continue to confirm a block firstly, which will cause the ledger's status ahead of utxoVM by 2 block-height and make utxoVM play to fail.