### PR TITLE
LedgerKeeper::fix utxoVM & ledger unequal error.

### DIFF
--- a/core/core/ledgerkeeper.go
+++ b/core/core/ledgerkeeper.go
@@ -545,7 +545,7 @@ func (lk *LedgerKeeper) getBlocks(ctx context.Context, targetPeer string, blockI
 	if err != nil {
 		return nil, ErrUnmarshal
 	}
-	lk.log.Info("ledgerkeeper::getBlocks::GET BLOCKS RESULT", "Logid", msg.GetHeader().GetLogid(), "From", msg.GetHeader().From, "LEN", len(blocksMsgBody.GetBlocksInfo()))
+	lk.log.Info("ledgerkeeper::getBlocks::GET BLOCKS RESULT", "Logid", msg.GetHeader().GetLogid(), "From", msg.GetHeader(), "LEN", len(blocksMsgBody.GetBlocksInfo()))
 	if len(blocksMsgBody.GetBlocksInfo()) == 0 && len(blockIds) > 1 {
 		// 目标节点完全未找到任何block
 		return nil, ErrTargetDataNotFound
@@ -616,7 +616,7 @@ func (lk *LedgerKeeper) handleGetBlockIds(ctx context.Context, msg *xuper_p2p.Xu
 		TipBlockId: localTip,
 		BlockIds:   make([][]byte, 0, headersCount),
 	}
-	lk.log.Debug("ledgerkeeper::handleGetBlockIds::GET_BLOCKIDS handling...", "Logid", msg.GetHeader().GetLogid(), "BEGIN HEADER", global.F(headerBlockId), "FROM", msg.GetHeader().From)
+	lk.log.Debug("ledgerkeeper::handleGetBlockIds::GET_BLOCKIDS handling...", "Logid", msg.GetHeader().GetLogid(), "BEGIN HEADER", global.F(headerBlockId), "FROM", msg.GetHeader())
 	// 已经是最高高度，直接返回tipBlockId
 	if bytes.Equal(localTip, headerBlockId) {
 		resBuf, _ := proto.Marshal(resultHeaders)
@@ -710,7 +710,7 @@ func (lk *LedgerKeeper) handleGetBlocks(ctx context.Context, msg *xuper_p2p.Xupe
 		resultBlocks = append(resultBlocks, block)
 		leftSize -= int64(proto.Size(block))
 	}
-	lk.log.Trace("ledgerkeeper::handleGetBlocks::GET_BLOCKS_RES handling...", "REQUIRE LIST", printStr, "FROM", msg.GetHeader().From)
+	lk.log.Trace("ledgerkeeper::handleGetBlocks::GET_BLOCKS_RES handling...", "REQUIRE LIST", printStr, "FROM", msg.GetHeader())
 	result := &pb.GetBlocksResponse{
 		BlocksInfo: resultBlocks,
 	}

--- a/core/core/ledgerkeeper.go
+++ b/core/core/ledgerkeeper.go
@@ -354,6 +354,9 @@ func (lk *LedgerKeeper) getPeerBlockIds(beginBlockId []byte, length int64, targe
 			response = msg
 		}
 	}
+	if response == nil {
+		return false, nil, ErrTargetPeerInvalid
+	}
 	headerMsgBody := &pb.GetBlockIdsResponse{}
 	err = proto.Unmarshal(response.GetData().GetMsgInfo(), headerMsgBody)
 	if err != nil {
@@ -547,6 +550,9 @@ func (lk *LedgerKeeper) getBlocks(ctx context.Context, targetPeer string, blockI
 		if msg.GetHeader().GetBcname() == lk.bcName {
 			response = msg
 		}
+	}
+	if response == nil {
+		return nil, ErrInternal
 	}
 	blocksMsgBody := &pb.GetBlocksResponse{}
 	err = proto.Unmarshal(response.GetData().GetMsgInfo(), blocksMsgBody)

--- a/core/p2p/p2pv2/server.go
+++ b/core/p2p/p2pv2/server.go
@@ -163,7 +163,7 @@ func (p *P2PServerV2) SendMessageWithResponse(ctx context.Context, msg *p2pPb.Xu
 		peersRes = peers.([]peer.ID)
 	}
 	percentage := msgOpts.Percentage
-	p.log.Trace("Server SendMessage with response", "logid", msg.GetHeader().GetLogid(), "bcname", msg.GetHeader().GetBcname,
+	p.log.Trace("Server SendMessage with response", "logid", msg.GetHeader().GetLogid(), "bcname", msg.GetHeader().GetBcname(),
 		"msgType", msg.GetHeader().GetType(), "checksum", msg.GetHeader().GetDataCheckSum(), "peers", peersRes)
 
 	if p.enableMetric {


### PR DESCRIPTION
PlayAndRepost might fail when the ledger tries to confirm a block, which causes return action in the code while the block has been put into the ledger incorrectly.
Unfortunately, a new sync task will continue to confirm a block firstly, which will cause the ledger's status ahead of utxoVM by 2 block-height and make utxoVM play to fail.