### PR TITLE
RFC: Add debug output for xdev && Allow options args to specify account  for unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ event_client
 # Log files
 *.log
 *.log.wf
+
+
+coverage.txt
+*.pem

--- a/core/cmd/xdev/internal/cmd/build.go
+++ b/core/cmd/xdev/internal/cmd/build.go
@@ -55,7 +55,7 @@ func newBuildCommand() *cobra.Command {
 			return c.build(args)
 		},
 	}
-	cmd.Flags().BoolVarP(&c.makeFileOnly, "makefile", "m", false, "generate makefile and exits")
+	cmd.Flags().BoolVarP(&c.makeFileOnly, "makefile", "m", false, "generate makefile and exit")
 	cmd.Flags().BoolVarP(&c.genCompileCommand, "compile_command", "p", false, "generate compile_commands.json for IDE")
 	cmd.Flags().StringVarP(&c.output, "output", "o", "", "output file name")
 	cmd.Flags().StringVarP(&c.compiler, "compiler", "", "docker", "compiler env docker|host")

--- a/core/cmd/xdev/internal/jstest/xchain/environment.go
+++ b/core/cmd/xdev/internal/jstest/xchain/environment.go
@@ -62,10 +62,6 @@ func newEnvironment() (*environment, error) {
 	}, nil
 }
 
-type OptionArgs struct {
-	Account string `json:"account"`
-	Amount  string `json:"amount"`
-}
 type deployArgs struct {
 	Name     string                 `json:"name"`
 	Code     string                 `json:"code"`
@@ -73,7 +69,7 @@ type deployArgs struct {
 	InitArgs map[string]interface{} `json:"init_args"`
 	Type     string                 `json:"type"`
 	ABIFile  string                 `json:"abi"`
-	Options  OptionArgs             `json:"options"`
+	Options  invokeOptions          `json:"options"`
 
 	trueArgs map[string][]byte
 	codeBuf  []byte

--- a/core/cmd/xdev/internal/jstest/xchain/environment.go
+++ b/core/cmd/xdev/internal/jstest/xchain/environment.go
@@ -3,6 +3,7 @@ package xchain
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -61,6 +62,10 @@ func newEnvironment() (*environment, error) {
 	}, nil
 }
 
+type OptionArgs struct {
+	Account string `json:"account"`
+	Amount  string `json:"amount"`
+}
 type deployArgs struct {
 	Name     string                 `json:"name"`
 	Code     string                 `json:"code"`
@@ -68,6 +73,7 @@ type deployArgs struct {
 	InitArgs map[string]interface{} `json:"init_args"`
 	Type     string                 `json:"type"`
 	ABIFile  string                 `json:"abi"`
+	Options  OptionArgs             `json:"options"`
 
 	trueArgs map[string][]byte
 	codeBuf  []byte
@@ -105,6 +111,7 @@ func (e *environment) Deploy(args deployArgs) (*ContractResponse, error) {
 		XMCache:        xcache,
 		ResourceLimits: contract.MaxLimits,
 		Core:           new(chainCore),
+		Initiator:      args.Options.Account,
 	}, dargs)
 	if err != nil {
 		return nil, err
@@ -113,6 +120,9 @@ func (e *environment) Deploy(args deployArgs) (*ContractResponse, error) {
 	err = e.model.Commit(xcache)
 	if err != nil {
 		return nil, err
+	}
+	if os.Getenv("DEBUG") != "" {
+		fmt.Printf(resp.String())
 	}
 	return newContractResponse(resp), nil
 }
@@ -154,7 +164,6 @@ func (e *environment) Invoke(name string, args invokeArgs) (*ContractResponse, e
 	if !ok {
 		return nil, errors.New("vm not found")
 	}
-
 	xcache := e.model.NewCache()
 
 	ctx, err := vm.NewContext(&contract.ContextConfig{

--- a/core/contract/vm.go
+++ b/core/contract/vm.go
@@ -2,6 +2,7 @@ package contract
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"sync"
 
@@ -34,6 +35,11 @@ type Response struct {
 	Body []byte `json:"body"`
 }
 
+func (r *Response) String() string {
+	// TODO @engjin body may be non-string
+	return fmt.Sprintf("{\"status\":\"%d\",\"message\":\"%s\",\"body\":\"%s\"}", r.Status, r.Message, string(r.Body))
+
+}
 func ToPBContractResponse(resp *Response) *pb.ContractResponse {
 	return &pb.ContractResponse{
 		Status:  int32(resp.Status),


### PR DESCRIPTION
## Description

What is the purpose of the change?

- Add Debug output for unit test when  DEBUG environment variable set, you can easily inspect resp.body and resp.message when assert failed without change youre test.js file 

- Allow specify account for unit test

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

