### PR TITLE
[fix]cmd/cli: response of evm with endorsing service

### DIFF
--- a/core/cmd/cli/comm_trans.go
+++ b/core/cmd/cli/comm_trans.go
@@ -148,7 +148,7 @@ func (c *CommTrans) GenPreExeRes(ctx context.Context) (
 			// print contract response of evm
 			err := printRespWithAbiForEVM(string(c.AbiCode), c.MethodName, res.Body)
 			if err != nil {
-				return nil, nil, nil
+				fmt.Printf("contract response: %s\n", string(res.Body))
 			}
 		}
 	}


### PR DESCRIPTION
## Description

There are two responses when invoking or query an evm contract with endorsing service.
One is `success`, and the other is response encoded with abi.
These two cases should be dealt with separately.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
