### PR TITLE
[fix]core/cmd/cli: check length of contract's response and add UTXOs from contracts

### DIFF
--- a/core/cmd/cli/comm_trans.go
+++ b/core/cmd/cli/comm_trans.go
@@ -907,6 +907,13 @@ func (c *CommTrans) GenRealTx(response *pb.PreExecWithSelectUTXOResponse,
 		Nonce:     global.GenNonce(),
 	}
 
+	if response.Response.GetUtxoInputs() != nil {
+		tx.TxInputs = append(tx.TxInputs, response.GetResponse().GetUtxoInputs()...)
+	}
+	if response.Response.GetUtxoOutputs() != nil {
+		tx.TxOutputs = append(tx.TxOutputs, response.GetResponse().GetUtxoOutputs()...)
+	}
+
 	desc, _ := c.GetDesc()
 	tx.Desc = desc
 	tx.TxInputsExt = response.GetResponse().GetInputs()

--- a/go.mod
+++ b/go.mod
@@ -54,4 +54,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.4
 )
 
-replace github.com/hyperledger/burrow => github.com/xuperchain/burrow v0.30.6-0.20200922024403-90193b5a35dd
+replace github.com/hyperledger/burrow => github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2

--- a/go.sum
+++ b/go.sum
@@ -637,8 +637,8 @@ github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4m
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/xuperchain/burrow v0.30.6-0.20200922024403-90193b5a35dd h1:t2rRvwBa+Ft7woP7tBOitpkgv2hFMcScbdTTfAG/mzs=
-github.com/xuperchain/burrow v0.30.6-0.20200922024403-90193b5a35dd/go.mod h1:ll86BjptGSd24apjKypG189UBzkaw4GPVRKDWvoOkn0=
+github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2 h1:v1HtuZh4qwFJ8fH4/au9rkdC07CMTrrBfNgfz77S0tw=
+github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2/go.mod h1:ll86BjptGSd24apjKypG189UBzkaw4GPVRKDWvoOkn0=
 github.com/xuperchain/log15 v0.0.0-20190620081506-bc88a9198230 h1:AWFZFbmLhY6VG6IIHD+9ZCgTCuvVRKoK+PRNaxqahl0=
 github.com/xuperchain/log15 v0.0.0-20190620081506-bc88a9198230/go.mod h1:90Da9GDXy9Yle79ZHSJY1c7X+1meBKsoX0vkRy09xis=
 github.com/xuperchain/wagon v0.6.1-0.20200313164333-db544e251599 h1:xh8MpzUZFmNOpeJyiiBCYOJq7gq7nRBU647y6e78Qms=

--- a/vendor/github.com/hyperledger/burrow/execution/evm/abi/primitives.go
+++ b/vendor/github.com/hyperledger/burrow/execution/evm/abi/primitives.go
@@ -539,6 +539,9 @@ func (e EVMAddress) pack(v interface{}) ([]byte, error) {
 }
 
 func (e EVMAddress) unpack(data []byte, offset int, v interface{}) (int, error) {
+	if len(data)-offset < ElementSize {
+		return 0, fmt.Errorf("%v: not enough data", e)
+	}
 	addr, err := crypto.AddressFromBytes(data[offset+ElementSize-crypto.AddressLength : offset+ElementSize])
 	if err != nil {
 		return 0, err
@@ -618,6 +621,9 @@ func (e EVMBytes) pack(v interface{}) ([]byte, error) {
 }
 
 func (e EVMBytes) unpack(data []byte, offset int, v interface{}) (int, error) {
+	if len(data)-offset < ElementSize {
+		return 0, fmt.Errorf("%v: not enough data", e)
+	}
 	if e.M == 0 {
 		s := EVMString{}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -201,7 +201,7 @@ github.com/huin/goupnp/httpu
 github.com/huin/goupnp/scpd
 github.com/huin/goupnp/soap
 github.com/huin/goupnp/ssdp
-# github.com/hyperledger/burrow v0.30.5 => github.com/xuperchain/burrow v0.30.6-0.20200922024403-90193b5a35dd
+# github.com/hyperledger/burrow v0.30.5 => github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2
 github.com/hyperledger/burrow/acm
 github.com/hyperledger/burrow/acm/acmstate
 github.com/hyperledger/burrow/acm/balance


### PR DESCRIPTION
## Description

What is the purpose of the change?
(1)check length before decoding Address and Bytes; 
(2)add UtxoInputs and UtxoOutputs generated by contracts.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)