### PR TITLE
config: change default log level from debug  to info

### DIFF
--- a/core/conf/xchain.yaml
+++ b/core/conf/xchain.yaml
@@ -11,7 +11,7 @@ log:
   # 是否打印命令行工具端口
   console: true
   # 日志等级
-  level: debug
+  level: info
 
 # RPC 服务暴露的端口
 tcpServer:


### PR DESCRIPTION
## Description

What is the purpose of the change?
Default log level as debug causeshex output of contract when deploy which increases deploy time and confuses user

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Change default log level to info

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
