### PR TITLE
evmevent bug fixed

### DIFF
--- a/core/contract/evm/creator.go
+++ b/core/contract/evm/creator.go
@@ -25,7 +25,7 @@ const (
 	initializeMethod    = "initialize"
 	evmParamJSONEncoded = "jsonEncoded"
 	evmInput            = "input"
-	uint8Type			= "*[]uint8"
+	uint8Type           = "*[]uint8"
 )
 
 type evmCreator struct {
@@ -209,10 +209,10 @@ func unpackEventFromAbi(abiByte []byte, contractName string, log *exec.LogEvent)
 		Contract: contractName,
 	}
 	event.Name = eventSpec.Name
-	for i:=0 ;i< len(vals);i++ {
+	for i := 0; i < len(vals); i++ {
 		t := reflect.TypeOf(vals[i])
-		if t.String() == uint8Type{
-			s := fmt.Sprintf("%x",vals[i])
+		if t.String() == uint8Type {
+			s := fmt.Sprintf("%x", vals[i])
 			vals[i] = s[1:]
 		}
 	}

--- a/core/contract/evm/creator.go
+++ b/core/contract/evm/creator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"reflect"
 
 	"github.com/hyperledger/burrow/crypto"
 	"github.com/hyperledger/burrow/execution/engine"
@@ -24,6 +25,7 @@ const (
 	initializeMethod    = "initialize"
 	evmParamJSONEncoded = "jsonEncoded"
 	evmInput            = "input"
+	uint8Type			= "*[]uint8"
 )
 
 type evmCreator struct {
@@ -207,6 +209,13 @@ func unpackEventFromAbi(abiByte []byte, contractName string, log *exec.LogEvent)
 		Contract: contractName,
 	}
 	event.Name = eventSpec.Name
+	for i:=0 ;i< len(vals);i++ {
+		t := reflect.TypeOf(vals[i])
+		if t.String() == uint8Type{
+			s := fmt.Sprintf("%x",vals[i])
+			vals[i] = s[1:]
+		}
+	}
 	data, err := json.Marshal(vals)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -55,4 +55,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.4
 )
 
-replace github.com/hyperledger/burrow => github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2
+replace github.com/hyperledger/burrow => github.com/xuperchain/burrow v0.30.6-0.20210304060557-02933899eeb0


### PR DESCRIPTION
修复当事件参数为string indexed时，事件内容记录下来的为不具识别的编码的问题。

原因定位：带有indexed的string以Keccak256Hash的形式存储在Log中，在pack时会将该Hash码转成[]uint8进行存储。数组进行json序列化，反序列化后json会将其当成string进行解析，从而解析成一串不可读的代码

修复方案：在[]uint8进行mashal前，将其转成string在进行序列化
