### PR TITLE
Add evm event

### DIFF
--- a/core/contract/evm/creator.go
+++ b/core/contract/evm/creator.go
@@ -157,7 +157,12 @@ func (e *evmInstance) Call(call *exec.CallEvent, exception *errors.Exception) er
 }
 
 func (e *evmInstance) Log(log *exec.LogEvent) error {
-	contractAbiByte, err := e.cp.GetContractAbi(e.ctx.ContractName)
+	contractName, _, err := DetermineEVMAddress(log.Address)
+	if err != nil {
+		return err
+	}
+
+	contractAbiByte, err := e.cp.GetContractAbi(contractName)
 	if err != nil {
 		return err
 	}
@@ -189,7 +194,7 @@ func (e *evmInstance) Log(log *exec.LogEvent) error {
 		fields = append(fields, m)
 	}
 	event := &xchainpb.ContractEvent{
-		Contract: e.ctx.ContractName,
+		Contract: contractName,
 	}
 	event.Name = eventSpec.Name
 	data, err := json.Marshal(fields)

--- a/core/contract/evm/creator.go
+++ b/core/contract/evm/creator.go
@@ -296,6 +296,3 @@ func init() {
 //
 //	return nil
 //}
-
-
-func

--- a/core/contract/evm/creator.go
+++ b/core/contract/evm/creator.go
@@ -1,6 +1,7 @@
 package evm
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -8,11 +9,13 @@ import (
 	"github.com/hyperledger/burrow/execution/engine"
 	"github.com/hyperledger/burrow/execution/errors"
 	"github.com/hyperledger/burrow/execution/evm"
+	"github.com/hyperledger/burrow/execution/evm/abi"
 	"github.com/hyperledger/burrow/execution/exec"
 
 	"github.com/xuperchain/xuperchain/core/contract"
 	"github.com/xuperchain/xuperchain/core/contract/bridge"
 	"github.com/xuperchain/xuperchain/core/contractsdk/go/pb"
+	xchainpb "github.com/xuperchain/xuperchain/core/pb"
 )
 
 const (
@@ -154,6 +157,47 @@ func (e *evmInstance) Call(call *exec.CallEvent, exception *errors.Exception) er
 }
 
 func (e *evmInstance) Log(log *exec.LogEvent) error {
+	contractAbiByte, err := e.cp.GetContractAbi(e.ctx.ContractName)
+	if err != nil {
+		return err
+	}
+	var eventID abi.EventID
+	copy(eventID[:], log.GetTopic(0).Bytes())
+
+	spec, err := abi.ReadSpec(contractAbiByte)
+	if err != nil {
+		return err
+	}
+	eventSpec, ok := spec.EventsByID[eventID]
+	if !ok {
+		return fmt.Errorf("The Event By ID Not Found ")
+	}
+
+	vals := make([]interface{}, len(eventSpec.Inputs))
+	for i := range vals {
+		vals[i] = new(string)
+	}
+	if err := abi.UnpackEvent(eventSpec, log.Topics, log.Data, vals...); err != nil {
+		return err
+	}
+
+	fields := []interface{}{}
+	for i := range vals {
+		val := vals[i].(*string)
+		m := make(map[string]string)
+		m[eventSpec.Inputs[i].Name] = *val
+		fields = append(fields, m)
+	}
+	event := &xchainpb.ContractEvent{
+		Contract: e.ctx.ContractName,
+	}
+	event.Name = eventSpec.Name
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return err
+	}
+	event.Body = data
+	e.ctx.Cache.AddEvent(event)
 	return nil
 }
 

--- a/core/contract/evm/creator_test.go
+++ b/core/contract/evm/creator_test.go
@@ -1,7 +1,12 @@
 package evm
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
+
+	"github.com/hyperledger/burrow/execution/exec"
+	abi2 "github.com/hyperledger/burrow/execution/evm/abi"
 
 	"github.com/xuperchain/xuperchain/core/contract/bridge"
 )
@@ -48,4 +53,36 @@ func TestNewEvmCreator(t *testing.T) {
 
 	creator.RemoveCache("contractName")
 
+}
+
+func TestUnpackEventFromAbi(t *testing.T){
+	abi := `[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"string","name":"key","type":"string"},{"indexed":false,"internalType":"uint256","name":"value","type":"uint256"}],"name":"increaseEvent","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"string","name":"key","type":"string"},{"indexed":false,"internalType":"uint256","name":"value","type":"uint256"}],"name":"increaseEvent1","type":"event"},{"inputs":[{"internalType":"string","name":"key","type":"string"}],"name":"get","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"getOwner","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"string","name":"key","type":"string"}],"name":"increase","outputs":[],"stateMutability":"payable","type":"function"}]`
+	contractName := "increaseEvent"
+
+	//==== 以下为组装log
+	eventAbi := `{"anonymous":false,"inputs":[{"indexed":false,"internalType":"string","name":"key","type":"string"},{"indexed":false,"internalType":"uint256","name":"value","type":"uint256"}],"name":"increaseEvent","type":"event"}`	//
+	type args struct {
+		Key string
+		Value  int64
+	}
+	in := &args{
+		Key:"test",
+		Value:12,
+	}
+	eventSpec := new(abi2.EventSpec)
+	err := json.Unmarshal([]byte(eventAbi), eventSpec)
+	if err != nil {
+		t.Error(err)
+	}
+	topics,data,err := abi2.PackEvent(eventSpec,in)
+	log := &exec.LogEvent{}
+	log.Topics = topics
+	log.Data = data
+	//====
+
+	event,err := unpackEventFromAbi([]byte(abi),contractName,log)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Printf("%+v\n",event)
 }

--- a/go.mod
+++ b/go.mod
@@ -55,4 +55,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.4
 )
 
-replace github.com/hyperledger/burrow => github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2
+replace github.com/hyperledger/burrow => github.com/xuperchain/burrow v0.30.6-0.20210304060557-02933899eeb0

--- a/go.sum
+++ b/go.sum
@@ -647,8 +647,8 @@ github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4m
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2 h1:v1HtuZh4qwFJ8fH4/au9rkdC07CMTrrBfNgfz77S0tw=
-github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2/go.mod h1:ll86BjptGSd24apjKypG189UBzkaw4GPVRKDWvoOkn0=
+github.com/xuperchain/burrow v0.30.6-0.20210304060557-02933899eeb0 h1:FMH63fb04Kkn7soMBO6XjV+kyyJQL3jnrKQaDJCt2to=
+github.com/xuperchain/burrow v0.30.6-0.20210304060557-02933899eeb0/go.mod h1:ll86BjptGSd24apjKypG189UBzkaw4GPVRKDWvoOkn0=
 github.com/xuperchain/log15 v0.0.0-20190620081506-bc88a9198230 h1:AWFZFbmLhY6VG6IIHD+9ZCgTCuvVRKoK+PRNaxqahl0=
 github.com/xuperchain/log15 v0.0.0-20190620081506-bc88a9198230/go.mod h1:90Da9GDXy9Yle79ZHSJY1c7X+1meBKsoX0vkRy09xis=
 github.com/xuperchain/wagon v0.6.1-0.20200313164333-db544e251599 h1:xh8MpzUZFmNOpeJyiiBCYOJq7gq7nRBU647y6e78Qms=

--- a/vendor/github.com/hyperledger/burrow/execution/evm/abi/packing.go
+++ b/vendor/github.com/hyperledger/burrow/execution/evm/abi/packing.go
@@ -74,6 +74,10 @@ func init() {
 
 func argGetter(argSpec []Argument, args []interface{}, ptr bool) (func(int) interface{}, error) {
 	if len(args) == 1 {
+		rt := reflect.TypeOf(args[0])
+		if rt.String() == "*big.Int"{
+			return func(i int) interface{} { return args[i] }, nil
+		}
 		rv := reflect.ValueOf(args[0])
 		if rv.Kind() == reflect.Ptr {
 			rv = rv.Elem()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -208,7 +208,7 @@ github.com/huin/goupnp/httpu
 github.com/huin/goupnp/scpd
 github.com/huin/goupnp/soap
 github.com/huin/goupnp/ssdp
-# github.com/hyperledger/burrow v0.30.5 => github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2
+# github.com/hyperledger/burrow v0.30.5 => github.com/xuperchain/burrow v0.30.6-0.20210304060557-02933899eeb0
 github.com/hyperledger/burrow/acm
 github.com/hyperledger/burrow/acm/acmstate
 github.com/hyperledger/burrow/acm/balance


### PR DESCRIPTION
修复当事件参数为string indexed时，事件内容记录下来的为不具识别的编码的问题。

原因定位：带有indexed的string以Keccak256Hash的形式存储在Log中，在pack时会将该Hash码转成[]uint8进行存储。数组进行json序列化，反序列化后json会将其当成string进行解析，从而解析成一串不可读的代码

修复方案：在[]uint8进行mashal前，将其转成string在进行序列化