### PR TITLE
修复当事件参数为string indexed时，事件内容编码异常。

### DIFF
--- a/core/contract/evm/creator.go
+++ b/core/contract/evm/creator.go
@@ -25,7 +25,6 @@ const (
 	initializeMethod    = "initialize"
 	evmParamJSONEncoded = "jsonEncoded"
 	evmInput            = "input"
-	uint8Type           = "*[]uint8"
 )
 
 type evmCreator struct {
@@ -208,10 +207,11 @@ func unpackEventFromAbi(abiByte []byte, contractName string, log *exec.LogEvent)
 	event := &xchainpb.ContractEvent{
 		Contract: contractName,
 	}
+	var uint8type = reflect.TypeOf((*[]uint8)(nil))
 	event.Name = eventSpec.Name
 	for i := 0; i < len(vals); i++ {
 		t := reflect.TypeOf(vals[i])
-		if t.String() == uint8Type {
+		if t == uint8type {
 			s := fmt.Sprintf("%x", vals[i])
 			vals[i] = s[1:]
 		}

--- a/core/contract/evm/creator.go
+++ b/core/contract/evm/creator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"reflect"
 
 	"github.com/hyperledger/burrow/crypto"
 	"github.com/hyperledger/burrow/execution/engine"
@@ -24,6 +25,7 @@ const (
 	initializeMethod    = "initialize"
 	evmParamJSONEncoded = "jsonEncoded"
 	evmInput            = "input"
+	uint8Type           = "*[]uint8"
 )
 
 type evmCreator struct {
@@ -207,6 +209,13 @@ func unpackEventFromAbi(abiByte []byte, contractName string, log *exec.LogEvent)
 		Contract: contractName,
 	}
 	event.Name = eventSpec.Name
+	for i := 0; i < len(vals); i++ {
+		t := reflect.TypeOf(vals[i])
+		if t.String() == uint8Type {
+			s := fmt.Sprintf("%x", vals[i])
+			vals[i] = s[1:]
+		}
+	}
 	data, err := json.Marshal(vals)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -55,4 +55,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.4
 )
 
-replace github.com/hyperledger/burrow => github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2
+replace github.com/hyperledger/burrow => github.com/xuperchain/burrow v0.30.6-0.20210304060557-02933899eeb0

--- a/go.sum
+++ b/go.sum
@@ -647,8 +647,8 @@ github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4m
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2 h1:v1HtuZh4qwFJ8fH4/au9rkdC07CMTrrBfNgfz77S0tw=
-github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2/go.mod h1:ll86BjptGSd24apjKypG189UBzkaw4GPVRKDWvoOkn0=
+github.com/xuperchain/burrow v0.30.6-0.20210304060557-02933899eeb0 h1:FMH63fb04Kkn7soMBO6XjV+kyyJQL3jnrKQaDJCt2to=
+github.com/xuperchain/burrow v0.30.6-0.20210304060557-02933899eeb0/go.mod h1:ll86BjptGSd24apjKypG189UBzkaw4GPVRKDWvoOkn0=
 github.com/xuperchain/log15 v0.0.0-20190620081506-bc88a9198230 h1:AWFZFbmLhY6VG6IIHD+9ZCgTCuvVRKoK+PRNaxqahl0=
 github.com/xuperchain/log15 v0.0.0-20190620081506-bc88a9198230/go.mod h1:90Da9GDXy9Yle79ZHSJY1c7X+1meBKsoX0vkRy09xis=
 github.com/xuperchain/wagon v0.6.1-0.20200313164333-db544e251599 h1:xh8MpzUZFmNOpeJyiiBCYOJq7gq7nRBU647y6e78Qms=

--- a/vendor/github.com/hyperledger/burrow/execution/evm/abi/packing.go
+++ b/vendor/github.com/hyperledger/burrow/execution/evm/abi/packing.go
@@ -74,6 +74,10 @@ func init() {
 
 func argGetter(argSpec []Argument, args []interface{}, ptr bool) (func(int) interface{}, error) {
 	if len(args) == 1 {
+		rt := reflect.TypeOf(args[0])
+		if rt.String() == "*big.Int"{
+			return func(i int) interface{} { return args[i] }, nil
+		}
 		rv := reflect.ValueOf(args[0])
 		if rv.Kind() == reflect.Ptr {
 			rv = rv.Elem()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -208,7 +208,7 @@ github.com/huin/goupnp/httpu
 github.com/huin/goupnp/scpd
 github.com/huin/goupnp/soap
 github.com/huin/goupnp/ssdp
-# github.com/hyperledger/burrow v0.30.5 => github.com/xuperchain/burrow v0.30.6-0.20210115120720-3da1be35a1e2
+# github.com/hyperledger/burrow v0.30.5 => github.com/xuperchain/burrow v0.30.6-0.20210304060557-02933899eeb0
 github.com/hyperledger/burrow/acm
 github.com/hyperledger/burrow/acm/acmstate
 github.com/hyperledger/burrow/acm/balance


### PR DESCRIPTION
修复当事件参数为string indexed时，事件内容记录下来的为不具识别的编码的问题。

原因定位：带有indexed的string以Keccak256Hash的形式存储在Log中，在pack时会将该Hash码转成[]uint8进行存储。数组进行json序列化，反序列化后json会将其当成string进行解析，从而解析成一串不可读的代码

修复方案：在[]uint8进行mashal前，将其转成string在进行序列化