### PR TITLE
fix nofee 模式下 SDK debug

### DIFF
--- a/core/server/server.go
+++ b/core/server/server.go
@@ -714,8 +714,8 @@ func (s *Server) PreExecWithSelectUTXO(ctx context.Context, in *pb.PreExecWithSe
 	}
 
 	totalAmount := in.GetTotalAmount() + fee
-
-	if totalAmount > 0 {
+    // when nofee is true,totalAmount is 0
+	if totalAmount >= 0 {
 		utxoInput := &pb.UtxoInput{
 			Bcname:    in.GetBcname(),
 			Address:   in.GetAddress(),


### PR DESCRIPTION
nofee 下 go-sdk 报错
xchain.go
	utxoOutput := &pb.UtxoOutput{
		//		UtxoList: utxolist,
		//		TotalSelected: totalSelected.String(),
		UtxoList:      response.UtxoOutput.UtxoList,
		TotalSelected: response.UtxoOutput.TotalSelected,
"response.UtxoOutput" will be nil when invoke contract
解决方法 在PreExecWithSelectUTXO 里的totalAmount 更新为 大于等于0
