### PR TITLE
fix bug: xdev build failed go 1.16

### DIFF
--- a/core/cmd/xdev/internal/jstest/deps.go
+++ b/core/cmd/xdev/internal/jstest/deps.go
@@ -24,3 +24,4 @@ func (t testDeps) WriteProfileTo(string, io.Writer, int) error { return nil }
 func (t testDeps) ImportPath() string                          { return "" }
 func (t testDeps) StartTestLog(io.Writer)                      {}
 func (t testDeps) StopTestLog() error                          { return nil }
+func (t testDeps) SetPanicOnExit0(bool)                        {}


### PR DESCRIPTION
## Description

go 1.16 xdev build failed.
go 1.16 testing.testDeps 接口增加了一个方法，因此 xdev 的 testDeps 需要实现此接口也需要增加这个方法，其他接口不动，保持兼容以前版本。
## Type of change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
