### PR TITLE
bugfix: tx vertification failed when put after delete 

### DIFF
--- a/core/contract/bridge/syscall_service.go
+++ b/core/contract/bridge/syscall_service.go
@@ -7,13 +7,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/xuperchain/xuperchain/core/xmodel"
 	"math/big"
 	"sort"
 
 	"github.com/xuperchain/xuperchain/core/contract"
 	pb "github.com/xuperchain/xuperchain/core/contractsdk/go/pb"
 	xchainpb "github.com/xuperchain/xuperchain/core/pb"
+	"github.com/xuperchain/xuperchain/core/xmodel"
 )
 
 var (

--- a/core/contract/bridge/syscall_service.go
+++ b/core/contract/bridge/syscall_service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/xuperchain/xuperchain/core/xmodel"
 	"math/big"
 	"sort"
 
@@ -308,6 +309,9 @@ func (c *SyscallService) NewIterator(ctx context.Context, in *pb.IteratorRequest
 	}
 	out := new(pb.IteratorResponse)
 	for iter.Next() && limit > 0 {
+		if xmodel.IsEmptyVersionedData(iter.Data()) {
+			continue
+		}
 		out.Items = append(out.Items, &pb.IteratorItem{
 			Key:   append([]byte(""), iter.Data().GetPureData().GetKey()...), //make a copy
 			Value: append([]byte(""), iter.Data().GetPureData().GetValue()...),


### PR DESCRIPTION
## Description

What is the purpose of the change?
skip empty versioned data   when iterator over xmodel.  it fixes the tx vertification  failed bug when put after delete. see #1042  for more detailes

Fixes # (issue)
#1042 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Please describe your solution to solve the issue or feature request.


