### PR TITLE
fix nofee bug: PreExecWithSelectUTXO response empty

### DIFF
--- a/service/rpc/api.go
+++ b/service/rpc/api.go
@@ -115,6 +115,10 @@ func (t *RpcServ) PreExecWithSelectUTXO(gctx context.Context,
 		return resp, err
 	}
 
+	// no fee, set response must.
+	resp.Bcname = req.GetBcname()
+	resp.Response = preExecRes.GetResponse()
+
 	// SelectUTXO
 	totalAmount := req.GetTotalAmount() + preExecRes.GetResponse().GetGasUsed()
 	if totalAmount < 1 {
@@ -136,8 +140,6 @@ func (t *RpcServ) PreExecWithSelectUTXO(gctx context.Context,
 	utxoOut.Header = req.GetHeader()
 
 	// 设置响应
-	resp.Bcname = req.GetBcname()
-	resp.Response = preExecRes.GetResponse()
 	resp.UtxoOutput = utxoOut
 
 	return resp, nil


### PR DESCRIPTION
## Description

nofee 场景，PreExecWithSelectUTXO 的 response 没有返回预执行的结果，已修复。


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

