### PR TITLE
fix bug control forcestop 

### DIFF
--- a/auto/control.sh
+++ b/auto/control.sh
@@ -76,7 +76,7 @@ start() {
     waitRun
     if [ "$?" != "0" ]; then
         echo "start timeout,force stop app."
-        forceStop
+        forcestop
         echo "start fail."
         exit 1
     fi


### PR DESCRIPTION
## Description

What is the purpose of the change?
 The wrong spelling of the "forceStop" uppercase and lowercase code in line 79 of the file control.sh makes the method forcestop unable to execute


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

