### PR TITLE
去掉 xchain-cli netURL preview 结果的换行符,在操作时会造成干扰

### DIFF
--- a/cmd/client/cmd/neturl_preview.go
+++ b/cmd/client/cmd/neturl_preview.go
@@ -48,9 +48,9 @@ func (n *NetURLPreviewCommand) previewNetURL(ctx context.Context) error {
 	}
 
 	if n.ipv6 != "" {
-		fmt.Printf("/ip6/%s/tcp/%s/p2p/%s\n", n.ipv6, n.port, pid)
+		fmt.Printf("/ip6/%s/tcp/%s/p2p/%s", n.ipv6, n.port, pid)
 	} else {
-		fmt.Printf("/ip4/%s/tcp/%s/p2p/%s\n", n.ip, n.port, pid)
+		fmt.Printf("/ip4/%s/tcp/%s/p2p/%s", n.ip, n.port, pid)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

What is the purpose of the change?

```xchain-cli netURL preview``` 返回结果没有换行符

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

  ###获取节点的 neturl,返回值最后一个换行符.....
  xc_node_neturl=`kubectl exec -it ${podName} -- ./xchain-cli netURL preview`

使用shell调用pod里的neturl,返回的字符串有换行符,对后续操作造成了影响
