### PR TITLE
修改getValidates函数的调试日志为Debug

### DIFF
--- a/core/consensus/common/chainedbft/smr/smr.go
+++ b/core/consensus/common/chainedbft/smr/smr.go
@@ -492,7 +492,7 @@ func (s *Smr) voteProposal(propsQC *pb.QuorumCert, voteTo, logid string) error {
 }
 
 func (s *Smr) getValidates(viewNumer int64) []*cons_base.CandidateInfo {
-	s.slog.Error("getValidates", "effectiveDelay", s.effectiveDelay, "s.vscView", s.vscView)
+	s.slog.Debug("getValidates", "effectiveDelay", s.effectiveDelay, "s.vscView", s.vscView)
 	// 根据不同共识的生效延时，判断当前view是否需要使用哪个验证集合，viewNumer为新视图，vscView为上次变更候选人视图
 	if s.effectiveDelay > 0 && viewNumer == s.vscView+s.effectiveDelay {
 		for _, v := range s.preValidates {


### PR DESCRIPTION
## Description

What is the purpose of the change?

Xpoa共识建立之后,会一直输出 lvl=eror msg=getValidates module=xchain effectiveDelay=1 s.vscView=xxx 异常日志,修改为debug

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?


