### PR TITLE
cli status add chainname filter

### DIFF
--- a/cmd/client/cmd/status.go
+++ b/cmd/client/cmd/status.go
@@ -65,7 +65,7 @@ func (s *StatusCommand) printXchainStatus(ctx context.Context) error {
 	if reply.Header.Error != pb.XChainErrorEnum_SUCCESS {
 		return errors.New(reply.Header.Error.String())
 	}
-	status := FromSystemStatusPB(reply.GetSystemsStatus())
+	status := FromSystemStatusPB(reply.GetSystemsStatus(), s.cli.RootOptions.Name)
 	if s.extractSpecificInfo(status) {
 		return nil
 	}

--- a/cmd/client/cmd/types.go
+++ b/cmd/client/cmd/types.go
@@ -396,9 +396,12 @@ type SystemStatus struct {
 }
 
 // FromSystemStatusPB systemstatus info
-func FromSystemStatusPB(statuspb *pb.SystemsStatus) *SystemStatus {
+func FromSystemStatusPB(statuspb *pb.SystemsStatus, cname string) *SystemStatus {
 	status := &SystemStatus{}
 	for _, chain := range statuspb.GetBcsStatus() {
+		if cname != "xuper" && chain.Bcname != cname {
+			continue
+		}
 		ledgerMeta := chain.GetMeta()
 		utxoMeta := chain.GetUtxoMeta()
 		ReservedContracts := utxoMeta.GetReservedContracts()


### PR DESCRIPTION
cli status 命令支持 name 选项，默认 xuper 显示所有链状态，指定其他链名显示指定平行链状态。