### PR TITLE
旧版的tdpos查询命令已经不可用，从cli的命令中剔除

### DIFF
--- a/cmd/client/cmd/tdpos.go
+++ b/cmd/client/cmd/tdpos.go
@@ -26,6 +26,6 @@ func NewTDposCommand(cli *Cli) *cobra.Command {
 	return cmd
 }
 
-func init() {
-	AddCommand(NewTDposCommand)
-}
+//func init() {
+//	AddCommand(NewTDposCommand)
+//}


### PR DESCRIPTION
## Description

旧版的tdpos查询命令已经不可用，从cli的命令中剔除

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

注释掉tdpos命令的注册

## How Has This Been Tested?

执行./client tdpos -h
返回unknown command "tdpos" for "xchain-cli"

