### PR TITLE
修复PruneLedger命令的子命令crypto注释错误

### DIFF
--- a/cmd/xchain/cmd/pruneledger.go
+++ b/cmd/xchain/cmd/pruneledger.go
@@ -62,7 +62,7 @@ func GetPruneLedgerCommand() *PruneLedgerCommand {
 	c.Cmd.Flags().StringVarP(&c.EnvConf,
 		"env_conf", "e", "./conf/env.yaml", "env config file path")
 	c.Cmd.Flags().StringVarP(&c.Crypto,
-		"crypto", "c", "default", "block chain name")
+		"crypto", "c", "default", "crypto type")
 
 	return c
 }


### PR DESCRIPTION
## Description

PruneLedger命令的子命令crypto注释错误

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

修复PruneLedger命令的子命令crypto注释错误

## How Has This Been Tested?

执行"xchain pruneLedger -h"显示crypto的注释应为crypto type
