### PR TITLE
add the configuration of the p2p node selection strategy when synchronizing blocks

### DIFF
--- a/conf/engine.yaml
+++ b/conf/engine.yaml
@@ -10,3 +10,7 @@ txIdCacheGCInterval: 10m
 maxBlockQueueSize: 100
 # min new parachain amount
 minNewChainAmount: "100"
+# SyncBlockFilterMode is the mode for filter peerID list policies, 0-SyncWithNearestBucket, 1-SyncWithFactorBucket
+syncBlockFilterMode: 0
+# SyncFactorForFactorBucketMode only use for SyncWithFactorBucket mode of SyncBlockFilterMode configuration item
+SyncFactorForFactorBucketMode: 0.5

--- a/data/mock/node1/conf/engine.yaml
+++ b/data/mock/node1/conf/engine.yaml
@@ -10,3 +10,7 @@ txIdCacheGCInterval: 10m
 maxBlockQueueSize: 100
 # min new parachain amount
 minNewChainAmount: "100"
+# SyncBlockFilterMode is the mode for filter peerID list policies, 0-SyncWithNearestBucket, 1-SyncWithFactorBucket
+syncBlockFilterMode: 0
+# SyncFactorForFactorBucketMode only use for SyncWithFactorBucket mode of SyncBlockFilterMode configuration item
+SyncFactorForFactorBucketMode: 0.5

--- a/data/mock/node2/conf/engine.yaml
+++ b/data/mock/node2/conf/engine.yaml
@@ -10,3 +10,7 @@ txIdCacheGCInterval: 10m
 maxBlockQueueSize: 100
 # min new parachain amount
 minNewChainAmount: "100"
+# SyncBlockFilterMode is the mode for filter peerID list policies, 0-SyncWithNearestBucket, 1-SyncWithFactorBucket
+syncBlockFilterMode: 0
+# SyncFactorForFactorBucketMode only use for SyncWithFactorBucket mode of SyncBlockFilterMode configuration item
+SyncFactorForFactorBucketMode: 0.5

--- a/data/mock/node3/conf/engine.yaml
+++ b/data/mock/node3/conf/engine.yaml
@@ -10,3 +10,7 @@ txIdCacheGCInterval: 10m
 maxBlockQueueSize: 100
 # min new parachain amount
 minNewChainAmount: "100"
+# SyncBlockFilterMode is the mode for filter peerID list policies, 0-SyncWithNearestBucket, 1-SyncWithFactorBucket
+syncBlockFilterMode: 0
+# SyncFactorForFactorBucketMode only use for SyncWithFactorBucket mode of SyncBlockFilterMode configuration item
+SyncFactorForFactorBucketMode: 0.5


### PR DESCRIPTION
## Description

add the configuration of the p2p node selection strategy when synchronizing blocks

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
